### PR TITLE
add more links to navbar

### DIFF
--- a/cfde_deriva/datapackage.py
+++ b/cfde_deriva/datapackage.py
@@ -167,7 +167,10 @@ class CfdeDataPackage (object):
                             { "name": "Subject", "url": "/chaise/recordset/#%s/CFDE:subject" % self.catalog._catalog_id },
                             { "name": "Project", "url": "/chaise/recordset/#%s/CFDE:project" % self.catalog._catalog_id },
                         ]
-                    }
+                    },
+                    { "name": "Dashboard", "url": "/dashboard.html" },
+                    { "name": "Documentation", "url": "#" },
+                    { "name": "Contact", "url": "#" }
                 ]
             }
         }

--- a/cfde_deriva/datapackage.py
+++ b/cfde_deriva/datapackage.py
@@ -169,8 +169,7 @@ class CfdeDataPackage (object):
                         ]
                     },
                     { "name": "Dashboard", "url": "/dashboard.html" },
-                    { "name": "Documentation", "url": "#" },
-                    { "name": "Contact", "url": "#" }
+                    { "name": "Documentation", "url": "https://cfde-published-documentation.readthedocs-hosted.com/en/latest/" }
                 ]
             }
         }


### PR DESCRIPTION
This PR makes the navbar on the landing page and recordset page more consistent.

We decided to put the navbar in an iframe on the landing page to remove the headache of having mixed dependencies (2 different versions of bootstrap). When doing this, I had to constrain the height of the iframe to only the height we want for the navbar. This caused the dropdown functionality to break on the landing page.

Since this is the case, I unset the `defaultCatalog` chaise config property in `chaise-config.js` and have defined my own set of configuration options that apply to the navbar on the landing page. Namely a different `navbarMenu` where the first option is only a link to the `collection` table recordset view. Once that page loads, the chaise config from the catalog annotation will be used with the dropdown working properly.

I added other options to `chaise-config.js` for styling purposes that can be absorbed into the catalog annotation once this iframe issue is resolved after the demo.