### PR TITLE
Column etl for searchbox

### DIFF
--- a/cfde_deriva/__init__.py
+++ b/cfde_deriva/__init__.py
@@ -1,7 +1,7 @@
 
 # not much here
 
-__version__ = '0.8'
+__version__ = '0.9'
 
 # use the modules you want...
 

--- a/cfde_deriva/configs/portal/biosample_kw.sql
+++ b/cfde_deriva/configs/portal/biosample_kw.sql
@@ -1,0 +1,188 @@
+WITH s AS (
+  SELECT
+    "RID",
+    json_group_array(DISTINCT kw) AS kw
+  FROM (
+
+    -- id_namespace
+    SELECT "RID", id_namespace AS kw FROM biosample
+    UNION
+
+    SELECT b."RID", n."name" AS kw
+    FROM biosample b
+    JOIN id_namespace n ON (b.id_namespace = n.id)
+    UNION
+
+    SELECT b."RID", n.abbreviation AS kw
+    FROM biosample b
+    JOIN id_namespace n ON (b.id_namespace = n.id)
+    WHERE n.abbreviation IS NOT NULL
+    UNION
+
+    -- local_id
+    SELECT "RID", local_id AS kw FROM biosample
+    UNION
+
+    -- persistent_id
+    SELECT "RID", persistent_id AS kw FROM biosample WHERE persistent_id IS NOT NULL
+    UNION
+
+    -- project_id_namespace, project_local_id
+    SELECT "RID", project_id_namespace AS kw FROM biosample
+    UNION
+
+    SELECT "RID", project_local_id AS kw FROM biosample
+    UNION
+
+    SELECT b."RID", p."name" AS kw
+    FROM biosample b
+    JOIN project p ON (b.project_id_namespace = p.id_namespace AND b.project_local_id = p.local_id)
+    UNION
+
+    SELECT b."RID", p.description AS kw
+    FROM biosample b
+    JOIN project p ON (b.project_id_namespace = p.id_namespace AND b.project_local_id = p.local_id)
+    WHERE p.description IS NOT NULL
+    UNION
+
+    -- ... super project facet
+    SELECT DISTINCT b."RID", pip.leader_project_id_namespace AS kw
+    FROM biosample b
+    JOIN project_in_project_transitive pip ON (b.project_id_namespace = pip.member_project_id_namespace AND b.project_local_id = pip.member_project_local_id)
+    UNION
+
+    SELECT DISTINCT b."RID", pip.leader_project_local_id AS kw
+    FROM biosample b
+    JOIN project_in_project_transitive pip ON (b.project_id_namespace = pip.member_project_id_namespace AND b.project_local_id = pip.member_project_local_id)
+    UNION
+
+    SELECT DISTINCT b."RID", p."name" AS kw
+    FROM biosample b
+    JOIN project_in_project_transitive pip ON (b.project_id_namespace = pip.member_project_id_namespace AND b.project_local_id = pip.member_project_local_id)
+    JOIN project p ON (p.id_namespace = pip.leader_project_id_namespace AND p.local_id = pip.leader_project_local_id)
+    UNION
+
+    -- anatomy
+    SELECT "RID", anatomy AS kw FROM biosample WHERE anatomy IS NOT NULL
+    UNION
+
+    SELECT b."RID", t."name" AS kw
+    FROM biosample b
+    JOIN anatomy t ON (b.anatomy = t.id)
+    UNION
+
+    -- ... subject taxonomy facet
+    SELECT b."RID", srt.taxonomy_id AS kw
+    FROM biosample b
+    JOIN biosample_from_subject bfs ON (b.id_namespace = bfs.biosample_id_namespace AND b.local_id = bfs.biosample_local_id)
+    JOIN subject_role_taxonomy srt ON (bfs.subject_id_namespace = srt.subject_id_namespace AND bfs.subject_local_id = srt.subject_local_id)
+    UNION
+
+    SELECT b."RID", t."name" AS kw
+    FROM biosample b
+    JOIN biosample_from_subject bfs ON (b.id_namespace = bfs.biosample_id_namespace AND b.local_id = bfs.biosample_local_id)
+    JOIN subject_role_taxonomy srt ON (bfs.subject_id_namespace = srt.subject_id_namespace AND bfs.subject_local_id = srt.subject_local_id)
+    JOIN ncbi_taxonomy t ON (srt.taxonomy_id = t.id)
+    UNION
+
+    -- ... subject role facet
+    SELECT b."RID", srt.role_id AS kw
+    FROM biosample b
+    JOIN biosample_from_subject bfs ON (b.id_namespace = bfs.biosample_id_namespace AND b.local_id = bfs.biosample_local_id)
+    JOIN subject_role_taxonomy srt ON (bfs.subject_id_namespace = srt.subject_id_namespace AND bfs.subject_local_id = srt.subject_local_id)
+    UNION
+
+    SELECT b."RID", t."name" AS kw
+    FROM biosample b
+    JOIN biosample_from_subject bfs ON (b.id_namespace = bfs.biosample_id_namespace AND b.local_id = bfs.biosample_local_id)
+    JOIN subject_role_taxonomy srt ON (bfs.subject_id_namespace = srt.subject_id_namespace AND bfs.subject_local_id = srt.subject_local_id)
+    JOIN subject_role t ON (srt.role_id = t.id)
+    UNION
+
+    -- ... subject granularity facet
+    SELECT b."RID", s.granularity AS kw
+    FROM biosample b
+    JOIN biosample_from_subject bfs ON (b.id_namespace = bfs.biosample_id_namespace AND b.local_id = bfs.biosample_local_id)
+    JOIN subject s ON (bfs.subject_id_namespace = s.id_namespace AND bfs.subject_local_id = s.local_id)
+    WHERE s.granularity IS NOT NULL
+    UNION
+
+    SELECT b."RID", t."name" AS kw
+    FROM biosample b
+    JOIN biosample_from_subject bfs ON (b.id_namespace = bfs.biosample_id_namespace AND b.local_id = bfs.biosample_local_id)
+    JOIN subject s ON (bfs.subject_id_namespace = s.id_namespace AND bfs.subject_local_id = s.local_id)
+    JOIN subject_granularity t ON (s.granularity = t.id)
+    UNION
+
+    -- ... file data-type facet
+    SELECT b."RID", f.data_type AS kw
+    FROM biosample b
+    JOIN file_describes_biosample fdb ON (b.id_namespace = fdb.biosample_id_namespace AND b.local_id = fdb.biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    WHERE f.data_type IS NOT NULL
+    UNION
+
+    SELECT b."RID", t."name" AS kw
+    FROM biosample b
+    JOIN file_describes_biosample fdb ON (b.id_namespace = fdb.biosample_id_namespace AND b.local_id = fdb.biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    JOIN data_type t ON (f.data_type = t.id)
+    UNION
+
+    -- ... file assay-type facet
+    SELECT b."RID", f.assay_type AS kw
+    FROM biosample b
+    JOIN file_describes_biosample fdb ON (b.id_namespace = fdb.biosample_id_namespace AND b.local_id = fdb.biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    WHERE f.assay_type IS NOT NULL
+    UNION
+
+    SELECT b."RID", t."name" AS kw
+    FROM biosample b
+    JOIN file_describes_biosample fdb ON (b.id_namespace = fdb.biosample_id_namespace AND b.local_id = fdb.biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    JOIN assay_type t ON (f.assay_type = t.id)
+    UNION
+
+    -- ... file file-format facet
+    SELECT b."RID", f.file_format AS kw
+    FROM biosample b
+    JOIN file_describes_biosample fdb ON (b.id_namespace = fdb.biosample_id_namespace AND b.local_id = fdb.biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    WHERE f.file_format IS NOT NULL
+    UNION
+
+    SELECT b."RID", t."name" AS kw
+    FROM biosample b
+    JOIN file_describes_biosample fdb ON (b.id_namespace = fdb.biosample_id_namespace AND b.local_id = fdb.biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    JOIN file_format t ON (f.file_format = t.id)
+    UNION
+
+    -- ... part of collection facet
+    SELECT DISTINCT b."RID", cic.leader_collection_id_namespace AS kw
+    FROM biosample b
+    JOIN biosample_in_collection bic ON (b.id_namespace = bic.biosample_id_namespace AND b.local_id = bic.biosample_local_id)
+    JOIN collection_in_collection_transitive cic ON (bic.collection_id_namespace = cic.member_collection_id_namespace AND bic.collection_local_id = cic.member_collection_local_id)
+    UNION
+
+    SELECT DISTINCT b."RID", cic.leader_collection_local_id AS kw
+    FROM biosample b
+    JOIN biosample_in_collection bic ON (b.id_namespace = bic.biosample_id_namespace AND b.local_id = bic.biosample_local_id)
+    JOIN collection_in_collection_transitive cic ON (bic.collection_id_namespace = cic.member_collection_id_namespace AND bic.collection_local_id = cic.member_collection_local_id)
+    UNION
+
+    SELECT DISTINCT b."RID", c."name" AS kw
+    FROM biosample b
+    JOIN biosample_in_collection bic ON (b.id_namespace = bic.biosample_id_namespace AND b.local_id = bic.biosample_local_id)
+    JOIN collection_in_collection_transitive cic ON (bic.collection_id_namespace = cic.member_collection_id_namespace AND bic.collection_local_id = cic.member_collection_local_id)
+    JOIN collection c ON (cic.leader_collection_id_namespace = c.id_namespace AND cic.leader_collection_local_id = c.local_id)
+
+  ) s
+  GROUP BY "RID"
+)
+UPDATE biosample AS v
+SET kw = s.kw
+FROM s
+WHERE v."RID" = s."RID"
+;

--- a/cfde_deriva/configs/portal/c2m2-level1-portal-model.json
+++ b/cfde_deriva/configs/portal/c2m2-level1-portal-model.json
@@ -121,6 +121,12 @@
                   "name": "mime_type",
                   "description": "A MIME type describing this file",
                   "type": "string"
+               },
+               {
+                  "name": "kw",
+                  "description": "A pre-computed set of keywords/strings used by the CFDE search UI.",
+                  "type": "array",
+                  "derivation_sql_path": "file_kw.sql"
                }
             ],
             "missingValues": [ "" ],
@@ -178,6 +184,7 @@
                "columns": true,
                "fkeys": true,
                "sources": {
+                  "search-box": {"or": [ {"source": "kw", "markdown_name": "File metadata keywords"} ]},
                   "S_id_namespace": {
                      "comment": "The namespace qualifier for the file ID.",
                      "source": [{"outbound": ["CFDE", "file_id_namespace_fkey"]}, "RID"]

--- a/cfde_deriva/configs/portal/c2m2-level1-portal-model.json
+++ b/cfde_deriva/configs/portal/c2m2-level1-portal-model.json
@@ -184,7 +184,7 @@
                "columns": true,
                "fkeys": true,
                "sources": {
-                  "search-box": {"or": [ {"source": "kw", "markdown_name": "File metadata keywords"} ]},
+                  "search-box": {"or": [ {"source": "kw", "markdown_name": "file metadata, anatomy, taxonomy", "comment": "file name, format, data-type, assay-type, anatomy, taxonomy, subject granularity, project, or collection keywords"} ]},
                   "S_id_namespace": {
                      "comment": "The namespace qualifier for the file ID.",
                      "source": [{"outbound": ["CFDE", "file_id_namespace_fkey"]}, "RID"]
@@ -420,6 +420,12 @@
                   "constraints": {
                      "pattern": "^UBERON:[0-9]+$"
                   }
+               },
+               {
+                  "name": "kw",
+                  "description": "A pre-computed set of keywords/strings used by the CFDE search UI.",
+                  "type": "array",
+                  "derivation_sql_path": "biosample_kw.sql"
                }
             ],
             "missingValues": [ "" ],
@@ -461,6 +467,7 @@
                "columns": true,
                "fkeys": true,
                "sources": {
+                  "search-box": {"or": [ {"source": "kw", "markdown_name": "biosample, file, subject metadata", "comment": "biosample identifers/anatomy, file format/assay/data type, subject granularity/role/taxonomy, project, collection keywords"} ]},
                   "S_id_namespace": {
                      "comment": "The namespace qualifier for the biosample ID.",
                      "source": [{"outbound": ["CFDE", "biosample_id_namespace_fkey"]}, "RID"]

--- a/cfde_deriva/configs/portal/c2m2-level1-portal-model.json
+++ b/cfde_deriva/configs/portal/c2m2-level1-portal-model.json
@@ -652,6 +652,12 @@
                   "constraints": {
                      "required": true
                   }
+               },
+               {
+                  "name": "kw",
+                  "description": "A pre-computed set of keywords/strings used by the CFDE search UI.",
+                  "type": "array",
+                  "derivation_sql_path": "biosample_kw.sql"
                }
             ],
             "missingValues": [ "" ],
@@ -693,6 +699,7 @@
                "columns": true,
                "fkeys": true,
                "sources": {
+                  "search-box": {"or": [ {"source": "kw", "markdown_name": "subject, biosample, file metadata", "comment": "subject identifiers/granularity/role/taxonomy, biosample anatomy, file format/assay/data type, project, collection keywords"} ]},
                   "S_id_namespace": {
                      "comment": "The namespace qualifier for the subject ID.",
                      "source": [{"outbound": ["CFDE", "subject_id_namespace_fkey"]}, "RID"]

--- a/cfde_deriva/configs/portal/c2m2-level1-portal-model.json
+++ b/cfde_deriva/configs/portal/c2m2-level1-portal-model.json
@@ -657,7 +657,7 @@
                   "name": "kw",
                   "description": "A pre-computed set of keywords/strings used by the CFDE search UI.",
                   "type": "array",
-                  "derivation_sql_path": "biosample_kw.sql"
+                  "derivation_sql_path": "subject_kw.sql"
                }
             ],
             "missingValues": [ "" ],

--- a/cfde_deriva/configs/portal/file_kw.sql
+++ b/cfde_deriva/configs/portal/file_kw.sql
@@ -1,0 +1,166 @@
+WITH s AS (
+  SELECT
+    "RID",
+    json_group_array(DISTINCT kw) AS kw
+  FROM (
+
+    -- id_namespace
+    SELECT "RID", id_namespace AS kw FROM file
+    UNION
+
+    SELECT f."RID", n."name" AS kw
+    FROM file f
+    JOIN id_namespace n ON (f.id_namespace = n.id)
+    UNION
+
+    SELECT f."RID", n.abbreviation AS kw
+    FROM file f
+    JOIN id_namespace n ON (f.id_namespace = n.id)
+    WHERE n.abbreviation IS NOT NULL
+    UNION
+
+    -- local_id
+    SELECT "RID", local_id AS kw FROM file
+    UNION
+
+    -- project_id_namespace, project_local_id
+    SELECT "RID", project_id_namespace AS kw FROM file
+    UNION
+
+    SELECT "RID", project_local_id AS kw FROM file
+    UNION
+
+    SELECT f."RID", p."name" AS kw
+    FROM file f
+    JOIN project p ON (f.project_id_namespace = p.id_namespace AND f.project_local_id = p.local_id)
+    UNION
+
+    SELECT f."RID", p.description AS kw
+    FROM file f
+    JOIN project p ON (f.project_id_namespace = p.id_namespace AND f.project_local_id = p.local_id)
+    WHERE p.description IS NOT NULL
+    UNION
+
+    -- file ... super project facet
+    SELECT DISTINCT f."RID", pip.leader_project_id_namespace AS kw
+    FROM file f
+    JOIN project_in_project_transitive pip ON (f.project_id_namespace = pip.member_project_id_namespace AND f.project_local_id = pip.member_project_local_id)
+    UNION
+
+    SELECT DISTINCT f."RID", pip.leader_project_local_id AS kw
+    FROM file f
+    JOIN project_in_project_transitive pip ON (f.project_id_namespace = pip.member_project_id_namespace AND f.project_local_id = pip.member_project_local_id)
+    UNION
+
+    SELECT DISTINCT f."RID", p."name" AS kw
+    FROM file f
+    JOIN project_in_project_transitive pip ON (f.project_id_namespace = pip.member_project_id_namespace AND f.project_local_id = pip.member_project_local_id)
+    JOIN project p ON (p.id_namespace = pip.leader_project_id_namespace AND p.local_id = pip.leader_project_local_id)
+    UNION
+
+    -- filename
+    SELECT "RID", filename AS kw FROM file WHERE filename IS NOT NULL
+    UNION
+
+    -- file_format
+    SELECT "RID", file_format AS kw FROM file WHERE file_format IS NOT NULL
+    UNION
+
+    SELECT f."RID", t."name" AS kw
+    FROM file f
+    JOIN file_format t ON (f.file_format = t.id)
+    UNION
+
+    -- data_type
+    SELECT "RID", data_type AS kw FROM file WHERE data_type IS NOT NULL
+    UNION
+
+    SELECT f."RID", t."name" AS kw
+    FROM file f
+    JOIN data_type t ON (f.data_type = t.id)
+    UNION
+
+    -- assay_type
+    SELECT "RID", assay_type AS kw FROM file WHERE assay_type IS NOT NULL
+    UNION
+
+    SELECT f."RID", t."name" AS kw
+    FROM file f
+    JOIN assay_type t ON (f.assay_type = t.id)
+    UNION
+
+    -- file ... anatomy facet
+    SELECT f."RID", anatomy AS kw
+    FROM file f
+    JOIN file_anatomy fa ON (f.id_namespace = fa.file_id_namespace AND f.local_id = fa.file_local_id)
+    UNION
+
+    SELECT f."RID", t."name" AS kw
+    FROM file f
+    JOIN file_anatomy fa ON (f.id_namespace = fa.file_id_namespace AND f.local_id = fa.file_local_id)
+    JOIN anatomy t ON (fa.anatomy = t.id)
+    UNION
+
+    -- file ... subject taxonomy facet
+    SELECT f."RID", fsrt.subject_taxonomy_id AS kw
+    FROM file f
+    JOIN file_subject_role_taxonomy fsrt ON (f.id_namespace = fsrt.file_id_namespace AND f.local_id = fsrt.file_local_id)
+    UNION
+
+    SELECT f."RID", t."name" AS kw
+    FROM file f
+    JOIN file_subject_role_taxonomy fsrt ON (f.id_namespace = fsrt.file_id_namespace AND f.local_id = fsrt.file_local_id)
+    JOIN ncbi_taxonomy t ON (fsrt.subject_taxonomy_id = t.id)
+    UNION
+
+    -- file ... subject role facet
+    SELECT f."RID", fsrt.subject_role_id AS kw
+    FROM file f
+    JOIN file_subject_role_taxonomy fsrt ON (f.id_namespace = fsrt.file_id_namespace AND f.local_id = fsrt.file_local_id)
+    UNION
+
+    SELECT f."RID", t."name" AS kw
+    FROM file f
+    JOIN file_subject_role_taxonomy fsrt ON (f.id_namespace = fsrt.file_id_namespace AND f.local_id = fsrt.file_local_id)
+    JOIN subject_role t ON (fsrt.subject_role_id = t.id)
+    UNION
+
+    -- file ... subject granularity facet
+    SELECT f."RID", fsg.subject_granularity AS kw
+    FROM file f
+    JOIN file_subject_granularity fsg ON (f.id_namespace = fsg.file_id_namespace AND f.local_id = fsg.file_local_id)
+    UNION
+
+    SELECT f."RID", t."name" AS kw
+    FROM file f
+    JOIN file_subject_granularity fsg ON (f.id_namespace = fsg.file_id_namespace AND f.local_id = fsg.file_local_id)
+    JOIN subject_granularity t ON (fsg.subject_granularity = t.id)
+    UNION
+
+    -- file ... part of collection facet
+    SELECT DISTINCT f."RID", cic.leader_collection_id_namespace AS kw
+    FROM file f
+    JOIN file_in_collection fic ON (f.id_namespace = fic.file_id_namespace AND f.local_id = fic.file_local_id)
+    JOIN collection_in_collection_transitive cic ON (fic.collection_id_namespace = cic.member_collection_id_namespace AND fic.collection_local_id = cic.member_collection_local_id)
+    UNION
+
+    SELECT DISTINCT f."RID", cic.leader_collection_local_id AS kw
+    FROM file f
+    JOIN file_in_collection fic ON (f.id_namespace = fic.file_id_namespace AND f.local_id = fic.file_local_id)
+    JOIN collection_in_collection_transitive cic ON (fic.collection_id_namespace = cic.member_collection_id_namespace AND fic.collection_local_id = cic.member_collection_local_id)
+    UNION
+
+    SELECT DISTINCT f."RID", c."name" AS kw
+    FROM file f
+    JOIN file_in_collection fic ON (f.id_namespace = fic.file_id_namespace AND f.local_id = fic.file_local_id)
+    JOIN collection_in_collection_transitive cic ON (fic.collection_id_namespace = cic.member_collection_id_namespace AND fic.collection_local_id = cic.member_collection_local_id)
+    JOIN collection c ON (cic.leader_collection_id_namespace = c.id_namespace AND cic.leader_collection_local_id = c.local_id)
+
+  ) s
+  GROUP BY "RID"
+)
+UPDATE file AS v
+SET kw = s.kw
+FROM s
+WHERE v."RID" = s."RID"
+;

--- a/cfde_deriva/configs/portal/file_kw.sql
+++ b/cfde_deriva/configs/portal/file_kw.sql
@@ -23,6 +23,10 @@ WITH s AS (
     SELECT "RID", local_id AS kw FROM file
     UNION
 
+    -- persistent_id
+    SELECT "RID", persistent_id AS kw FROM file WHERE persistent_id IS NOT NULL
+    UNION
+
     -- project_id_namespace, project_local_id
     SELECT "RID", project_id_namespace AS kw FROM file
     UNION
@@ -41,7 +45,7 @@ WITH s AS (
     WHERE p.description IS NOT NULL
     UNION
 
-    -- file ... super project facet
+    -- ... super project facet
     SELECT DISTINCT f."RID", pip.leader_project_id_namespace AS kw
     FROM file f
     JOIN project_in_project_transitive pip ON (f.project_id_namespace = pip.member_project_id_namespace AND f.project_local_id = pip.member_project_local_id)
@@ -89,7 +93,7 @@ WITH s AS (
     JOIN assay_type t ON (f.assay_type = t.id)
     UNION
 
-    -- file ... anatomy facet
+    -- ... anatomy facet
     SELECT f."RID", anatomy AS kw
     FROM file f
     JOIN file_anatomy fa ON (f.id_namespace = fa.file_id_namespace AND f.local_id = fa.file_local_id)
@@ -101,7 +105,7 @@ WITH s AS (
     JOIN anatomy t ON (fa.anatomy = t.id)
     UNION
 
-    -- file ... subject taxonomy facet
+    -- ... subject taxonomy facet
     SELECT f."RID", fsrt.subject_taxonomy_id AS kw
     FROM file f
     JOIN file_subject_role_taxonomy fsrt ON (f.id_namespace = fsrt.file_id_namespace AND f.local_id = fsrt.file_local_id)
@@ -113,7 +117,7 @@ WITH s AS (
     JOIN ncbi_taxonomy t ON (fsrt.subject_taxonomy_id = t.id)
     UNION
 
-    -- file ... subject role facet
+    -- ... subject role facet
     SELECT f."RID", fsrt.subject_role_id AS kw
     FROM file f
     JOIN file_subject_role_taxonomy fsrt ON (f.id_namespace = fsrt.file_id_namespace AND f.local_id = fsrt.file_local_id)
@@ -125,7 +129,7 @@ WITH s AS (
     JOIN subject_role t ON (fsrt.subject_role_id = t.id)
     UNION
 
-    -- file ... subject granularity facet
+    -- ... subject granularity facet
     SELECT f."RID", fsg.subject_granularity AS kw
     FROM file f
     JOIN file_subject_granularity fsg ON (f.id_namespace = fsg.file_id_namespace AND f.local_id = fsg.file_local_id)
@@ -137,7 +141,7 @@ WITH s AS (
     JOIN subject_granularity t ON (fsg.subject_granularity = t.id)
     UNION
 
-    -- file ... part of collection facet
+    -- ... part of collection facet
     SELECT DISTINCT f."RID", cic.leader_collection_id_namespace AS kw
     FROM file f
     JOIN file_in_collection fic ON (f.id_namespace = fic.file_id_namespace AND f.local_id = fic.file_local_id)

--- a/cfde_deriva/configs/portal/subject_kw.sql
+++ b/cfde_deriva/configs/portal/subject_kw.sql
@@ -1,0 +1,190 @@
+WITH s AS (
+  SELECT
+    "RID",
+    json_group_array(DISTINCT kw) AS kw
+  FROM (
+
+    -- id_namespace
+    SELECT "RID", id_namespace AS kw FROM subject
+    UNION
+
+    SELECT s."RID", n."name" AS kw
+    FROM subject s
+    JOIN id_namespace n ON (s.id_namespace = n.id)
+    UNION
+
+    SELECT s."RID", n.abbreviation AS kw
+    FROM subject s
+    JOIN id_namespace n ON (s.id_namespace = n.id)
+    WHERE n.abbreviation IS NOT NULL
+    UNION
+
+    -- local_id
+    SELECT "RID", local_id AS kw FROM subject
+    UNION
+
+    -- persistent_id
+    SELECT "RID", persistent_id AS kw FROM subject WHERE persistent_id IS NOT NULL
+    UNION
+
+    -- project_id_namespace, project_local_id
+    SELECT "RID", project_id_namespace AS kw FROM subject
+    UNION
+
+    SELECT "RID", project_local_id AS kw FROM subject
+    UNION
+
+    SELECT s."RID", p."name" AS kw
+    FROM subject s
+    JOIN project p ON (s.project_id_namespace = p.id_namespace AND s.project_local_id = p.local_id)
+    UNION
+
+    SELECT s."RID", p.description AS kw
+    FROM subject s
+    JOIN project p ON (s.project_id_namespace = p.id_namespace AND s.project_local_id = p.local_id)
+    WHERE p.description IS NOT NULL
+    UNION
+
+    -- ... super project facet
+    SELECT DISTINCT s."RID", pip.leader_project_id_namespace AS kw
+    FROM subject s
+    JOIN project_in_project_transitive pip ON (s.project_id_namespace = pip.member_project_id_namespace AND s.project_local_id = pip.member_project_local_id)
+    UNION
+
+    SELECT DISTINCT s."RID", pip.leader_project_local_id AS kw
+    FROM subject s
+    JOIN project_in_project_transitive pip ON (s.project_id_namespace = pip.member_project_id_namespace AND s.project_local_id = pip.member_project_local_id)
+    UNION
+
+    SELECT DISTINCT s."RID", p."name" AS kw
+    FROM subject s
+    JOIN project_in_project_transitive pip ON (s.project_id_namespace = pip.member_project_id_namespace AND s.project_local_id = pip.member_project_local_id)
+    JOIN project p ON (p.id_namespace = pip.leader_project_id_namespace AND p.local_id = pip.leader_project_local_id)
+    UNION
+
+    -- granularity
+    SELECT "RID", granularity AS kw FROM subject WHERE granularity IS NOT NULL
+    UNION
+
+    SELECT s."RID", t."name" AS kw
+    FROM subject s
+    JOIN subject_granularity t ON (s.granularity = t.id)
+    UNION
+
+    -- ... subject taxonomy facet
+    SELECT s."RID", srt.taxonomy_id AS kw
+    FROM subject s
+    JOIN subject_role_taxonomy srt ON (srt.subject_id_namespace = s.id_namespace AND srt.subject_local_id = s.local_id)
+    UNION
+
+    SELECT s."RID", t."name" AS kw
+    FROM subject s
+    JOIN subject_role_taxonomy srt ON (srt.subject_id_namespace = s.id_namespace AND srt.subject_local_id = s.local_id)
+    JOIN ncbi_taxonomy t ON (srt.taxonomy_id = t.id)
+    UNION
+
+    -- ... subject role facet
+    SELECT s."RID", srt.role_id AS kw
+    FROM subject s
+    JOIN subject_role_taxonomy srt ON (srt.subject_id_namespace = s.id_namespace AND srt.subject_local_id = s.local_id)
+    UNION
+
+    SELECT s."RID", t."name" AS kw
+    FROM subject s
+    JOIN subject_role_taxonomy srt ON (srt.subject_id_namespace = s.id_namespace AND srt.subject_local_id = s.local_id)
+    JOIN subject_role t ON (srt.role_id = t.id)
+    UNION
+
+    -- ... file_format facet
+    SELECT s."RID", file_format AS kw
+    FROM subject s
+    JOIN biosample_from_subject bfs ON (s.id_namespace = bfs.subject_id_namespace AND s.local_id = bfs.subject_local_id)
+    JOIN file_describes_biosample fdb USING (biosample_id_namespace, biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    WHERE file_format IS NOT NULL
+    UNION
+
+    SELECT s."RID", t."name" AS kw
+    FROM subject s
+    JOIN biosample_from_subject bfs ON (s.id_namespace = bfs.subject_id_namespace AND s.local_id = bfs.subject_local_id)
+    JOIN file_describes_biosample fdb USING (biosample_id_namespace, biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    JOIN file_format t ON (f.file_format = t.id)
+    UNION
+
+    -- ... data_type facet
+    SELECT s."RID", data_type AS kw
+    FROM subject s
+    JOIN biosample_from_subject bfs ON (s.id_namespace = bfs.subject_id_namespace AND s.local_id = bfs.subject_local_id)
+    JOIN file_describes_biosample fdb USING (biosample_id_namespace, biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    WHERE data_type IS NOT NULL
+    UNION
+
+    SELECT s."RID", t."name" AS kw
+    FROM subject s
+    JOIN biosample_from_subject bfs ON (s.id_namespace = bfs.subject_id_namespace AND s.local_id = bfs.subject_local_id)
+    JOIN file_describes_biosample fdb USING (biosample_id_namespace, biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    JOIN data_type t ON (f.data_type = t.id)
+    UNION
+
+    -- ... assay_type facet
+    SELECT s."RID", assay_type AS kw
+    FROM subject s
+    JOIN biosample_from_subject bfs ON (s.id_namespace = bfs.subject_id_namespace AND s.local_id = bfs.subject_local_id)
+    JOIN file_describes_biosample fdb USING (biosample_id_namespace, biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    WHERE assay_type IS NOT NULL
+    UNION
+
+    SELECT s."RID", t."name" AS kw
+    FROM subject s
+    JOIN biosample_from_subject bfs ON (s.id_namespace = bfs.subject_id_namespace AND s.local_id = bfs.subject_local_id)
+    JOIN file_describes_biosample fdb USING (biosample_id_namespace, biosample_local_id)
+    JOIN file f ON (fdb.file_id_namespace = f.id_namespace AND fdb.file_local_id = f.local_id)
+    JOIN assay_type t ON (f.assay_type = t.id)
+    UNION
+
+    -- ... anatomy facet
+    SELECT s."RID", anatomy AS kw
+    FROM subject s
+    JOIN biosample_from_subject bfs ON (s.id_namespace = bfs.subject_id_namespace AND s.local_id = bfs.subject_local_id)
+    JOIN biosample b ON (bfs.biosample_id_namespace = b.id_namespace AND bfs.biosample_local_id = b.local_id)
+    WHERE anatomy IS NOT NULL
+    UNION
+
+    SELECT s."RID", t."name" AS kw
+    FROM subject s
+    JOIN biosample_from_subject bfs ON (s.id_namespace = bfs.subject_id_namespace AND s.local_id = bfs.subject_local_id)
+    JOIN biosample b ON (bfs.biosample_id_namespace = b.id_namespace AND bfs.biosample_local_id = b.local_id)
+    JOIN anatomy t ON (b.anatomy = t.id)
+    UNION
+
+    -- ... part of collection facet
+    SELECT DISTINCT s."RID", cic.leader_collection_id_namespace AS kw
+    FROM subject s
+    JOIN subject_in_collection sic ON (s.id_namespace = sic.subject_id_namespace AND s.local_id = sic.subject_local_id)
+    JOIN collection_in_collection_transitive cic ON (sic.collection_id_namespace = cic.member_collection_id_namespace AND sic.collection_local_id = cic.member_collection_local_id)
+    UNION
+
+    SELECT DISTINCT s."RID", cic.leader_collection_local_id AS kw
+    FROM subject s
+    JOIN subject_in_collection sic ON (s.id_namespace = sic.subject_id_namespace AND s.local_id = sic.subject_local_id)
+    JOIN collection_in_collection_transitive cic ON (sic.collection_id_namespace = cic.member_collection_id_namespace AND sic.collection_local_id = cic.member_collection_local_id)
+    UNION
+
+    SELECT DISTINCT s."RID", c."name" AS kw
+    FROM subject s
+    JOIN subject_in_collection sic ON (s.id_namespace = sic.subject_id_namespace AND s.local_id = sic.subject_local_id)
+    JOIN collection_in_collection_transitive cic ON (sic.collection_id_namespace = cic.member_collection_id_namespace AND sic.collection_local_id = cic.member_collection_local_id)
+    JOIN collection c ON (cic.leader_collection_id_namespace = c.id_namespace AND cic.leader_collection_local_id = c.local_id)
+
+  ) s
+  GROUP BY "RID"
+)
+UPDATE subject AS v
+SET kw = s.kw
+FROM s
+WHERE v."RID" = s."RID"
+;

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -794,7 +794,7 @@ def main(subcommand, *args):
         else:
             raise TypeError('"reconfigure" requires exactly one positional argument: submission_id')
 
-        row = registry.get_datapackage(id)
+        row = registry.get_datapackage(submission_id)
         reconfigure_submission(row)
     elif subcommand == 'reconfigure-all':
         for row in registry.list_datapackages():

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -258,19 +258,27 @@ class Submission (object):
 
             def dpt_update2(name, path):
                 """Update status of resource following content upload"""
-                self.registry.update_datapackage_table(
-                    self.datapackage_id,
-                    self.rname_to_pos[name],
-                    status= terms.cfde_registry_dpt_status.content_ready
-                )
+                try:
+                    pos = self.rname_to_pos[name],
+                    self.registry.update_datapackage_table(
+                        self.datapackage_id,
+                        self.rname_to_pos[name],
+                        status= terms.cfde_registry_dpt_status.content_ready
+                    )
+                except KeyError as e:
+                    logger.debug("Swallowing dpt_update2 callback for table %s lacking position in datapackage" % (name,))
 
             def dpt_error2(name, path, diagnostics):
-                self.registry.update_datapackage_table(
-                    self.datapackage_id,
-                    self.rname_to_pos[name],
-                    status= terms.cfde_registry_dpt_status.content_error,
-                    diagnostics= diagnostics,
-                )
+                try:
+                    pos = self.rname_to_pos[name],
+                    self.registry.update_datapackage_table(
+                        self.datapackage_id,
+                        pos,
+                        status= terms.cfde_registry_dpt_status.content_error,
+                        diagnostics= diagnostics,
+                    )
+                except KeyError as e:
+                    logger.debug("Swallowing dpt_error2 callback for table %s lacking position in datapackage" % (name,))
 
             if dp['status'] not in {
                     terms.cfde_registry_dp_status.check_valid,
@@ -287,11 +295,10 @@ class Submission (object):
             next_error_state = terms.cfde_registry_dp_status.content_error
             self.load_sqlite(self.content_path, self.sqlite_filename, table_error_callback=dpt_error2)
             self.registry.update_datapackage(self.datapackage_id, status=terms.cfde_registry_dp_status.check_valid)
-            self.upload_datapackage_content(self.review_catalog, self.content_path, table_done_callback=dpt_update2, table_error_callback=dpt_error2)
 
             next_error_state = terms.cfde_registry_dp_status.ops_error
-            self.prepare_sqlite_derived_tables(self.sqlite_filename)
-            self.upload_derived_content(self.review_catalog, self.sqlite_filename)
+            self.prepare_sqlite_derived_data(self.sqlite_filename)
+            self.upload_sqlite_content(self.review_catalog, self.sqlite_filename, table_done_callback=dpt_update2, table_error_callback=dpt_error2)
 
             review_browse_url = '%s/chaise/recordset/#%s/CFDE:file' % (
                 self.review_catalog._base_server_uri,
@@ -640,8 +647,8 @@ class Submission (object):
             submitted_dp.sqlite_import_data_files(conn, onconflict='skip', table_error_callback=table_error_callback)
 
     @classmethod
-    def prepare_sqlite_derived_tables(cls, sqlite_filename):
-        """Prepare derived table content via SQL queries in the C2M2 portal model.
+    def prepare_sqlite_derived_data(cls, sqlite_filename):
+        """Prepare derived content via SQL queries in the C2M2 portal model.
 
         This method will clear and recompute the derived results
         each time it is invoked.
@@ -650,7 +657,7 @@ class Submission (object):
         canon_dp = CfdeDataPackage(portal_schema_json)
         # this with block produces a transaction in sqlite3
         with sqlite3.connect(sqlite_filename) as conn:
-            logger.debug('Building derived tables in %s' % (sqlite_filename,))
+            logger.debug('Building derived data in %s' % (sqlite_filename,))
             canon_dp.sqlite_do_etl(conn)
 
     @classmethod
@@ -705,29 +712,18 @@ class Submission (object):
         canon_dp.set_catalog(catalog, registry)
         if provision:
             canon_dp.provision() # get the model deployed
-            canon_dp.load_data_files(onconflict='skip') # get the built-in vocabularies deployed
         # TBD: annotate with submission ID for easier ops/inventory purposes?
         canon_dp.apply_custom_config() # get the chaise hints deloyed
         return catalog
 
     @classmethod
-    def upload_datapackage_content(cls, catalog, content_path, table_done_callback=None, table_error_callback=None):
-        """Idempotently upload submission content from datapackage into review catalog."""
-        packagefile = cls.datapackage_name_from_path(content_path)
-        submitted_dp = CfdeDataPackage(packagefile)
-        submitted_dp.set_catalog(catalog)
-        # TBD: pass through our registry knowledge of tables already in content-ready status?
-        # TBD: restartable onconflict=skip here means we cannot validate whether there are duplicates?
-        submitted_dp.load_data_files(onconflict='skip', table_done_callback=table_done_callback, table_error_callback=table_error_callback)
-
-    @classmethod
-    def upload_derived_content(cls, catalog, sqlite_filename):
-        """Idempotently upload prepared review content in sqlite db into review catalog."""
+    def upload_sqlite_content(cls, catalog, sqlite_filename, table_done_callback=None, table_error_callback=None):
+        """Idempotently upload (augmented) datapackage content in sqlite db into review catalog."""
         with sqlite3.connect(sqlite_filename) as conn:
             logger.debug('Idempotently uploading derived ETL data from %s' % (sqlite_filename,))
             canon_dp = CfdeDataPackage(portal_schema_json)
             canon_dp.set_catalog(catalog)
-            canon_dp.load_sqlite_etl_tables(conn, onconflict='skip')
+            canon_dp.load_sqlite_tables(conn, onconflict='skip', table_done_callback=table_done_callback, table_error_callback=table_error_callback)
 
 def main(subcommand, *args):
     """Ugly test-harness for data submission library.

--- a/cfde_deriva/tableschema.py
+++ b/cfde_deriva/tableschema.py
@@ -587,8 +587,8 @@ def make_type(type, format):
         return builtin_types.int8
     if type == "number":
         return builtin_types.float8
-    if type == "list":
-        # assume a list is a list of strings for now...
+    if type == "array":
+        # assume array is a list of strings for now...
         return builtin_types["text[]"]
     raise ValueError('no mapping defined yet for type=%s format=%s' % (type, format))
 


### PR DESCRIPTION
This PR lightlyl refactors the datapackage submission process to allow for ETL scripts to compute a derived column which can augment core entities. Such ETL is then used to build a keywords column, `kw`, used by the portal UI config to customize the Chaise searchbox behavior for `file`, `biosample`, and `subject` tables.