### PR TITLE
Remove Favorite Substance

### DIFF
--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -1379,16 +1379,7 @@
          },
          "deriva": {
             "table_config": {
-               "stable_key_columns": ["id"],
-               "user_favorites": {
-                  "storage_table": {
-                     "catalog": "registry",
-                     "schema": "CFDE",
-                     "table": "favorite_substance",
-                     "favorited_key_columns": ["substance"],
-                     "user_id_column": "user_id"
-                  }
-               }
+               "stable_key_columns": ["id"]
             },
             "source_definitions": {
                "columns": true,
@@ -3011,7 +3002,7 @@
             ]
          }
       },
-      
+
       {
          "profile": "tabular-data-resource",
          "name": "collection",
@@ -8340,7 +8331,7 @@
                      "required": true
                   }
                },
-               
+
                {
                   "name": "phenotypes",
                   "description": "The numeric ID of the phenotype terms qualifiying the described entities.",

--- a/cfde_deriva/configs/registry/cfde-registry-model.json
+++ b/cfde_deriva/configs/registry/cfde-registry-model.json
@@ -4796,7 +4796,6 @@
                   ["CFDE", "favorite_anatomy_user_id_fkey"],
                   ["CFDE", "favorite_disease_user_id_fkey"],
                   ["CFDE", "favorite_gene_user_id_fkey"],
-                  ["CFDE", "favorite_substance_user_id_fkey"],
                   ["CFDE", "favorite_compound_user_id_fkey"],
                   ["CFDE", "favorite_assay_type_user_id_fkey"],
                   ["CFDE", "favorite_data_type_user_id_fkey"],


### PR DESCRIPTION
Remove the favorite_substance entry in the visible foreign keys on my profile record page. Remove the favorite configuration in the table display annotation for substance.

I wasn't sure if we should remove the favorite association table or leave it just in case we wanted it in the future. If we do want to remove it, this is the configuration in the registry model json.
https://github.com/nih-cfde/cfde-deriva/blob/master/cfde_deriva/configs/registry/cfde-registry-model.json#L5488-L5578