### PR TITLE
Add facets for compound

### DIFF
--- a/cfde_deriva/__init__.py
+++ b/cfde_deriva/__init__.py
@@ -1,7 +1,7 @@
 
 # not much here
 
-__version__ = '3.0'
+__version__ = '4.0'
 
 # use the modules you want...
 

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -1247,6 +1247,14 @@
                         "nid"
                      ]
                   },
+                  "S_substance": {
+                     "markdown_name": "Substance",
+                     "comment": "Substances associated with the compound.",
+                     "source": [
+                        {"inbound": ["CFDE", "substance_compound_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_subject": {
                      "markdown_name": "Subject",
                      "comment": "Subjects linked to this compound term.",
@@ -1292,8 +1300,8 @@
                   "description"
                ],
                "filter": {"and": [
-                  {"source": "id"},
                   {"source": "name"},
+                  {"sourcekey": "S_substance"},
                   {"sourcekey": "S_collection"},
                   {"sourcekey": "S_file"},
                   {"sourcekey": "S_biosample"},
@@ -1302,6 +1310,7 @@
             },
             "visible_foreign_keys": {
                "*": [
+                  {"sourcekey": "S_substance"},
                   {"sourcekey": "S_file"},
                   {"sourcekey": "S_biosample"},
                   {"sourcekey": "S_subject"}
@@ -1391,6 +1400,13 @@
                         "nid"
                      ]
                   },
+                  "S_compound": {
+                     "markdown_name": "Compound",
+                     "source": [
+                        {"outbound": ["CFDE", "substance_compound_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_subject": {
                      "markdown_name": "Subject",
                      "comment": "Subjects linked to this substance term.",
@@ -1433,11 +1449,17 @@
                "*": [
                   "id",
                   "name",
+                  {"sourcekey": "S_compound"},
+                  "description"
+               ],
+               "compact": [
+                  "id",
+                  "name",
                   "description"
                ],
                "filter": {"and": [
-                  {"source": "id"},
                   {"source": "name"},
+                  {"sourcekey": "S_compound"},
                   {"sourcekey": "S_collection"},
                   {"sourcekey": "S_file"},
                   {"sourcekey": "S_biosample"},

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -8366,6 +8366,14 @@
                   }
                },
                {
+                  "name": "compounds",
+                  "description": "The numeric ID of the compound terms qualifiying the described entities.",
+                  "type": "object",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
                   "name": "genes",
                   "description": "The numeric ID of gene qualifying the described entities.",
                   "type": "object",
@@ -9338,6 +9346,51 @@
                   "constraint_name": "core_fact_substance_substance_fkey",
                   "reference": {
                      "resource": "substance",
+                     "fields": "nid"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "core_fact_compound",
+         "description": "An exploded representation of the core_fact.compounds array column as a binary association.",
+         "schema": {
+            "fields": [
+               {
+                  "name": "core_fact",
+                  "title": "Numeric ID",
+                  "description": "The numeric ID of a core_fact record in the portal.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "compound",
+                  "description": "The numeric ID of a term found in the core_fact.compounds array column.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true
+                  }
+               }
+            ],
+            "primaryKey": ["core_fact", "compound"],
+            "foreignKeys": [
+               {
+                  "fields": "core_fact",
+                  "constraint_name": "core_fact_compound_core_fact_fkey",
+                  "reference": {
+                     "resource": "core_fact",
+                     "fields": "nid"
+                  }
+               },
+               {
+                  "fields": "compound",
+                  "constraint_name": "core_fact_compound_compound_fkey",
+                  "reference": {
+                     "resource": "compound",
                      "fields": "nid"
                   }
                }

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -1242,9 +1242,8 @@
                "sources": {
                   "S_core_fact": {
                      "source": [
-                        {"inbound": ["CFDE", "substance_compound_fkey"]},
-                        {"inbound": ["CFDE", "core_fact_substance_compound_fkey"]},
-                        {"outbound": ["CFDE", "core_fact_substance_core_fact_fkey"]},
+                        {"inbound": ["CFDE", "core_fact_compound_compound_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_compound_core_fact_fkey"]},
                         "nid"
                      ]
                   },
@@ -3776,6 +3775,16 @@
                         "nid"
                      ]
                   },
+                  "S_compound": {
+                     "markdown_name": "Compound",
+                     "comment": "A compound linked to a biosample or subject.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "core_fact_compound_core_fact_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_compound_compound_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_gene": {
                      "markdown_name": "Gene",
                      "comment": "A gene linked to a biosample.",
@@ -3866,6 +3875,7 @@
                   {"sourcekey": "S_disease_slim"},
                   {"sourcekey": "S_disease"},
                   {"sourcekey": "S_substance"},
+                  {"sourcekey": "S_compound"},
                   {"sourcekey": "S_gene"},
                   {"sourcekey": "S_phenotype"},
                   {"sourcekey": "S_dcc"},
@@ -4642,6 +4652,16 @@
                         "nid"
                      ]
                   },
+                  "S_compound": {
+                     "markdown_name": "Compound",
+                     "comment": "A compound linked to the biosample or subject.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "core_fact_compound_core_fact_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_compound_compound_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_gene": {
                      "markdown_name": "Gene",
                      "comment": "A gene linked to the biosample.",
@@ -4817,6 +4837,7 @@
                   {"sourcekey": "S_disease"},
                   {"sourcekey": "S_phenotype"},
                   {"sourcekey": "S_substance"},
+                  {"sourcekey": "S_compound"},
                   {"sourcekey": "S_gene"},
                   {"sourcekey": "S_age_at_sampling"},
                   {"sourcekey": "S_sex"},
@@ -5366,6 +5387,16 @@
                         "nid"
                      ]
                   },
+                  "S_compound_search": {
+                     "markdown_name": "Compound",
+                     "comment": "A compound linked to the biosample or subject.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "core_fact_compound_core_fact_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_compound_compound_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_taxonomy": {
                      "markdown_name": "Subject Taxonomy",
                      "comment": "The taxonomy concept(s) characterizing the subject of the biosampling.",
@@ -5578,6 +5609,7 @@
                   {"sourcekey": "S_disease_search"},
                   {"sourcekey": "S_phenotype_search"},
                   {"sourcekey": "S_substance_search"},
+                  {"sourcekey": "S_compound_search"},
                   {"sourcekey": "S_gene"},
                   {"sourcekey": "S_dcc"},
                   {"sourcekey": "S_super_projects"},
@@ -5988,6 +6020,26 @@
                         "nid"
                      ]
                   },
+                  "S_compound_search": {
+                     "markdown_name": "Compound",
+                     "comment": "A compound linked to the biosample or subject.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "core_fact_compound_core_fact_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_compound_compound_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_compound": {
+                     "markdown_name": "Compound",
+                     "comment": "A compound linked to the subject.",
+                     "source": [
+                        {"inbound": ["CFDE", "subject_substance_subject_fkey"]},
+                        {"outbound": ["CFDE", "subject_substance_substance_fkey"]},
+                        {"outbound": ["CFDE", "substance_compound_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_gene": {
                      "markdown_name": "Gene",
                      "comment": "A gene linked to the biosample.",
@@ -6371,6 +6423,7 @@
                   {"sourcekey": "S_disease_search"},
                   {"sourcekey": "S_phenotype_search"},
                   {"sourcekey": "S_substance_search"},
+                  {"sourcekey": "S_compound_search"},
                   {"sourcekey": "S_gene"},
                   {"sourcekey": "S_role"},
                   {"sourcekey": "S_anatomy_slim"},
@@ -8846,6 +8899,10 @@
                      "comment": "A substance CV term associated with a set of C2M2 entities.",
                      "source": [{"inbound": ["CFDE", "core_fact_substance_core_fact_fkey"]}, {"outbound": ["CFDE", "core_fact_substance_substance_fkey"]}, "nid"]
                   },
+                  "S_compounds": {
+                     "comment": "A compound CV term associated with a set of C2M2 entities.",
+                     "source": [{"inbound": ["CFDE", "core_fact_compound_core_fact_fkey"]}, {"outbound": ["CFDE", "core_fact_compound_compound_fkey"]}, "nid"]
+                  },
                   "S_genes": {
                      "comment": "A gene CV term associated with a set of C2M2 entities.",
                      "source": [{"inbound": ["CFDE", "core_fact_gene_core_fact_fkey"]}, {"outbound": ["CFDE", "core_fact_gene_gene_fkey"]}, "nid"]
@@ -8915,6 +8972,7 @@
                   {"sourcekey": "S_projects"},
                   {"sourcekey": "S_diseases"},
                   {"sourcekey": "S_substances"},
+                  {"sourcekey": "S_compounds"},
                   {"sourcekey": "S_genes"},
                   {"sourcekey": "S_assay_types"},
                   {"sourcekey": "S_data_types"},
@@ -8996,7 +9054,16 @@
                      "comment": "Substance term qualifying the set of C2M2 entities.",
                      "display": {
                         "template_engine": "handlebars",
-                        "markdown_pattern": "{{#if (gt _substances.length \"0\")}}{{_subsances.length}} values{{/if}}"
+                        "markdown_pattern": "{{#if (gt _substances.length \"0\")}}{{_substances.length}} values{{/if}}"
+                     }
+                  },
+                  {
+                     "markdown_name": "Compound",
+                     "source": "compounds",
+                     "comment": "Compound term qualifying the set of C2M2 entities.",
+                     "display": {
+                        "template_engine": "handlebars",
+                        "markdown_pattern": "{{#if (gt _compounds.length \"0\")}}{{_compounds.length}} values{{/if}}"
                      }
                   },
                   {
@@ -9037,6 +9104,7 @@
                   {"sourcekey": "S_anatomies"},
                   {"sourcekey": "S_diseases"},
                   {"sourcekey": "S_substances"},
+                  {"sourcekey": "S_compounds"},
                   {"sourcekey": "S_genes"},
                   {"sourcekey": "S_granularities"},
                   {"sourcekey": "S_species"},

--- a/cfde_deriva/configs/portal_prep/cfde-portal-prep.json
+++ b/cfde_deriva/configs/portal_prep/cfde-portal-prep.json
@@ -4119,6 +4119,14 @@
                   }
                },
                {
+                  "name": "compounds",
+                  "description": "The numeric ID of the compound terms qualifiying the described entities.",
+                  "type": "array",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
                   "name": "genes",
                   "description": "The numeric ID of gene qualifying the described entities.",
                   "type": "array",
@@ -4423,6 +4431,7 @@
                "phenotypes",
                "diseases",
                "substances",
+               "compounds",
                "genes",
                "sexes",
                "races",
@@ -4714,6 +4723,52 @@
                   "constraint_name": "core_fact_substance_substance_fkey",
                   "reference": {
                      "resource": "substance",
+                     "fields": "nid"
+                  }
+               }
+            ]
+         },
+         "derivation_sql_path": null
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "core_fact_compound",
+         "description": "An exploded representation of the core_fact.compounds array column as a binary association.",
+         "schema": {
+            "fields": [
+               {
+                  "name": "core_fact",
+                  "title": "Numeric ID",
+                  "description": "The numeric ID of a core_fact record in the portal.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "compound",
+                  "description": "The numeric ID of a term found in the core_fact.compounds array column.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true
+                  }
+               }
+            ],
+            "primaryKey": ["core_fact", "compound"],
+            "foreignKeys": [
+               {
+                  "fields": "core_fact",
+                  "constraint_name": "core_fact_compound_core_fact_fkey",
+                  "reference": {
+                     "resource": "core_fact",
+                     "fields": "nid"
+                  }
+               },
+               {
+                  "fields": "compound",
+                  "constraint_name": "core_fact_compound_compound_fkey",
+                  "reference": {
+                     "resource": "compound",
                      "fields": "nid"
                   }
                }

--- a/cfde_deriva/configs/portal_prep/core_fact.sql
+++ b/cfde_deriva/configs/portal_prep/core_fact.sql
@@ -60,6 +60,16 @@ SELECT
     '[]'
   ) AS substances,
   COALESCE((
+      SELECT json_sorted(json_group_array(DISTINCT a.compound))
+      FROM (
+        SELECT v.compound FROM file_describes_subject fds JOIN subject_substance a ON (fds.subject = a.subject) JOIN substance v ON (a.substance = v.nid) WHERE fds.file = f.nid
+        UNION
+        SELECT v.compound FROM file_describes_biosample fdb JOIN biosample_substance a ON (fdb.biosample = a.biosample) JOIN substance v ON (a.substance = v.nid) WHERE fds.file = f.nid
+      ) a
+    ),
+    '[]'
+  ) AS compounds,
+  COALESCE((
       SELECT json_sorted(json_group_array(DISTINCT a.gene)) FROM file_describes_biosample fdb JOIN biosample_gene a ON (fdb.biosample = a.biosample) WHERE fdb.file = f.nid
     ),
     '[]'
@@ -143,6 +153,7 @@ CREATE INDEX IF NOT EXISTS file_facts_combo_idx ON file_facts(
     phenotypes,
     diseases,
     substances,
+    compounds,
     genes,
     sexes,
     races,
@@ -182,6 +193,7 @@ INSERT INTO core_fact (
     phenotypes,
     diseases,
     substances,
+    compounds,
     genes,
     sexes,
     races,
@@ -234,6 +246,7 @@ SELECT
   ff.phenotypes,
   ff.diseases,
   ff.substances,
+  ff.compounds,
   ff.genes,
   ff.sexes,
   ff.races,
@@ -286,6 +299,7 @@ FROM (
     ff.phenotypes,
     ff.diseases,
     ff.substances,
+    ff.compounds,
     ff.genes,
     ff.sexes,
     ff.races,
@@ -344,6 +358,7 @@ WHERE u.nid = ff.nid
   AND ff.phenotypes = cf.phenotypes
   AND ff.diseases = cf.diseases
   AND ff.substances = cf.substances
+  AND ff.compounds = cf.compounds
   AND ff.genes = cf.genes
   AND ff.sexes = cf.sexes
   AND ff.races = cf.races
@@ -423,6 +438,16 @@ SELECT
     ),
     '[]'
   ) AS substances,
+  COALESCE((
+      SELECT json_sorted(json_group_array(DISTINCT a.substance))
+      FROM (
+        SELECT v.compound FROM biosample_from_subject bfs JOIN subject_substance a ON (bfs.subject = a.subject) JOIN sunstance v ON (a.substance = v.nid) WHERE bfs.biosample = b.nid
+        UNION
+        SELECT v.compound FROM biosample_substance a JOIN substance v ON (a.substance = v.nid) WHERE a.biosample = b.nid
+      ) a
+    ),
+    '[]'
+  ) AS compounds,
   COALESCE((
       SELECT json_sorted(json_group_array(DISTINCT a.gene)) FROM biosample_gene a WHERE a.biosample = b.nid
     ),
@@ -523,6 +548,7 @@ CREATE INDEX IF NOT EXISTS biosample_facts_combo_idx ON biosample_facts(
     phenotypes,
     diseases,
     substances,
+    compounds,
     genes,
     sexes,
     races,
@@ -562,6 +588,7 @@ INSERT INTO core_fact (
     phenotypes,
     diseases,
     substances,
+    compounds,
     genes,
     sexes,
     races,
@@ -614,6 +641,7 @@ SELECT
   bf.phenotypes,
   bf.diseases,
   bf.substances,
+  bf.compounds,
   bf.genes,
   bf.sexes,
   bf.races,
@@ -666,6 +694,7 @@ FROM (
     bf.phenotypes,
     bf.diseases,
     bf.substances,
+    bf.compounds,
     bf.genes,
     bf.sexes,
     bf.races,
@@ -724,6 +753,7 @@ WHERE u.nid = bf.nid
   AND bf.phenotypes = cf.phenotypes
   AND bf.diseases = cf.diseases
   AND bf.substances = cf.substances
+  AND bf.compounds = cf.compounds
   AND bf.genes = cf.genes
   AND bf.sexes = cf.sexes
   AND bf.races = cf.races
@@ -803,6 +833,16 @@ SELECT
     ),
     '[]'
   ) AS substances,
+  COALESCE((
+      SELECT json_sorted(json_group_array(DISTINCT a.substance))
+      FROM (
+        SELECT v.compound FROM subject_substance a JOIN substance v ON (a.substance = v.nid) WHERE a.subject = s.nid
+        UNION
+        SELECT v.compound FROM biosample_from_subject bfs JOIN biosample_substance a ON (bfs.biosample = a.biosample) JOIN substance v ON (a.substance = v.nid) WHERE bfs.subject = s.nid
+      ) a
+    ),
+    '[]'
+  ) AS compounds,
   COALESCE((
       SELECT json_sorted(json_group_array(DISTINCT a.gene)) FROM biosample_from_subject bfs JOIN biosample_gene a ON (bfs.biosample = a.biosample) WHERE bfs.subject = s.nid
     ),
@@ -895,6 +935,7 @@ CREATE INDEX IF NOT EXISTS subject_facts_combo_idx ON subject_facts(
     phenotypes,
     diseases,
     substances,
+    compounds,
     genes,
     sexes,
     races,
@@ -934,6 +975,7 @@ INSERT INTO core_fact (
     phenotypes,
     diseases,
     substances,
+    compounds,
     genes,
     sexes,
     races,
@@ -986,6 +1028,7 @@ SELECT
   sf.phenotypes,
   sf.diseases,
   sf.substances,
+  sf.compounds,
   sf.genes,
   sf.sexes,
   sf.races,
@@ -1038,6 +1081,7 @@ FROM (
     sf.phenotypes,
     sf.diseases,
     sf.substances,
+    sf.compounds,
     sf.genes,
     sf.sexes,
     sf.races,
@@ -1096,6 +1140,7 @@ WHERE u.nid = sf.nid
   AND sf.phenotypes = cf.phenotypes
   AND sf.diseases = cf.diseases
   AND sf.substances = cf.substances
+  AND sf.compounds = cf.compounds
   AND sf.genes = cf.genes
   AND sf.sexes = cf.sexes
   AND sf.races = cf.races
@@ -1194,6 +1239,18 @@ SELECT
     ),
     '[]'
   ) AS substances,
+  COALESCE((
+      SELECT json_sorted(json_group_array(DISTINCT s.value))
+      FROM (
+        SELECT j.value FROM file_in_collection fic, file f, core_fact cf, json_each(cf.compounds) j WHERE fic.collection = col.nid AND fic.file = f.nid AND f.core_fact = cf.nid
+        UNION
+        SELECT j.value FROM biosample_in_collection bic, biosample b, core_fact cf, json_each(cf.compounds) j WHERE bic.collection = col.nid AND bic.biosample = b.nid AND b.core_fact = cf.nid
+        UNION
+        SELECT j.value FROM subject_in_collection sic, subject s, core_fact cf, json_each(cf.compounds) j WHERE sic.collection = col.nid AND sic.subject = s.nid AND s.core_fact = cf.nid
+      ) s
+    ),
+    '[]'
+  ) AS compounds,
   COALESCE((
       SELECT json_sorted(json_group_array(DISTINCT s.value))
       FROM (
@@ -1398,6 +1455,7 @@ CREATE INDEX IF NOT EXISTS collection_facts_combo_idx ON collection_facts(
     phenotypes,
     diseases,
     substances,
+    compounds,
     genes,
     sexes,
     races,
@@ -1437,6 +1495,7 @@ INSERT INTO core_fact (
     phenotypes,
     diseases,
     substances,
+    compounds,
     genes,
     sexes,
     races,
@@ -1489,6 +1548,7 @@ SELECT
   colf.phenotypes,
   colf.diseases,
   colf.substances,
+  colf.compounds,
   colf.genes,
   colf.sexes,
   colf.races,
@@ -1541,6 +1601,7 @@ FROM (
     colf.phenotypes,
     colf.diseases,
     colf.substances,
+    colf.compounds,
     colf.genes,
     colf.sexes,
     colf.races,
@@ -1599,6 +1660,7 @@ WHERE u.nid = colf.nid
   AND colf.phenotypes = cf.phenotypes
   AND colf.diseases = cf.diseases
   AND colf.substances = cf.substances
+  AND colf.compounds = cf.compounds
   AND colf.genes = cf.genes
   AND colf.sexes = cf.sexes
   AND colf.races = cf.races

--- a/cfde_deriva/configs/portal_prep/core_fact.sql
+++ b/cfde_deriva/configs/portal_prep/core_fact.sql
@@ -64,7 +64,7 @@ SELECT
       FROM (
         SELECT v.compound FROM file_describes_subject fds JOIN subject_substance a ON (fds.subject = a.subject) JOIN substance v ON (a.substance = v.nid) WHERE fds.file = f.nid
         UNION
-        SELECT v.compound FROM file_describes_biosample fdb JOIN biosample_substance a ON (fdb.biosample = a.biosample) JOIN substance v ON (a.substance = v.nid) WHERE fds.file = f.nid
+        SELECT v.compound FROM file_describes_biosample fdb JOIN biosample_substance a ON (fdb.biosample = a.biosample) JOIN substance v ON (a.substance = v.nid) WHERE fdb.file = f.nid
       ) a
     ),
     '[]'
@@ -439,9 +439,9 @@ SELECT
     '[]'
   ) AS substances,
   COALESCE((
-      SELECT json_sorted(json_group_array(DISTINCT a.substance))
+      SELECT json_sorted(json_group_array(DISTINCT a.compound))
       FROM (
-        SELECT v.compound FROM biosample_from_subject bfs JOIN subject_substance a ON (bfs.subject = a.subject) JOIN sunstance v ON (a.substance = v.nid) WHERE bfs.biosample = b.nid
+        SELECT v.compound FROM biosample_from_subject bfs JOIN subject_substance a ON (bfs.subject = a.subject) JOIN substance v ON (a.substance = v.nid) WHERE bfs.biosample = b.nid
         UNION
         SELECT v.compound FROM biosample_substance a JOIN substance v ON (a.substance = v.nid) WHERE a.biosample = b.nid
       ) a
@@ -834,7 +834,7 @@ SELECT
     '[]'
   ) AS substances,
   COALESCE((
-      SELECT json_sorted(json_group_array(DISTINCT a.substance))
+      SELECT json_sorted(json_group_array(DISTINCT a.compound))
       FROM (
         SELECT v.compound FROM subject_substance a JOIN substance v ON (a.substance = v.nid) WHERE a.subject = s.nid
         UNION

--- a/cfde_deriva/configs/portal_prep/core_fact_kw.sql
+++ b/cfde_deriva/configs/portal_prep/core_fact_kw.sql
@@ -27,6 +27,8 @@ FROM (
       cfde_keywords_merge_agg(dis.synonyms),
       cfde_keywords_agg(subst.id, subst.name, subst.description),
       cfde_keywords_merge_agg(subst.synonyms),
+      cfde_keywords_agg(cmpd.id, cmpd.name, cmpd.description),
+      cfde_keywords_merge_agg(cmpd.synonyms),
       cfde_keywords_agg(gn.id, gn.name, gn.description),
       cfde_keywords_merge_agg(gn.synonyms),
 
@@ -66,6 +68,8 @@ FROM (
   LEFT JOIN disease dis ON (json_extract(disj.value, '$[0]') = dis.nid)
   LEFT JOIN json_each(cf.substances) substj
   LEFT JOIN substance subst ON (substj.value = subst.nid)
+  LEFT JOIN json_each(cf.compounds) cmpdj
+  LEFT JOIN compound cmpd ON (cmpdj.value = cmpd.nid)
   LEFT JOIN json_each(cf.genes) gnj
   LEFT JOIN gene gn ON (gnj.value = gn.nid)
 

--- a/cfde_deriva/datapackage.py
+++ b/cfde_deriva/datapackage.py
@@ -1248,6 +1248,7 @@ LIMIT 1;
             'phenotype': 'phenotypes',
             'disease': 'diseases',
             'substance': 'substances',
+            'compound': 'compounds',
             'gene': 'genes',
             'sex': 'sexes',
             'race': 'races',


### PR DESCRIPTION
The compound cv is more abstract than substance and preferred for faceted search. To support this, compound is added as a dimension to the core_fact table and then used in facet definitions.