### PR TITLE
Resource markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ model or data updates.
 
 #### Delete registry
 
-AN existing registry can be deleted, e.g. to remove a parallel test
+An existing registry can be deleted, e.g. to remove a parallel test
 registry.
 
 `python -m cfde_deriva.registry delete [<catalog_id>]`
@@ -459,3 +459,37 @@ FQDN.
 
 `python -m cfde_deriva.registry fixup-fqdn [<catalog_id>]`
 
+#### Upload resource markdown
+
+Curated, markdown-formatted resource information can be uploaded to
+augment vocabulary terms known by the registry.
+
+`python -m cfde_deriva.registry upload-resources vocabname.json...`
+
+One or more JSON files are supplied and must be named by a vocabulary
+table name known by the registry plus the suffix `.json`. For example:
+
+- `anatomy.json`
+- `assay_type.json`
+- `ethnicity.json`
+
+This list is not exhaustive, so see other C2M2 documentation for
+more vocabulary names.
+
+The structure of each input JSON file is an array of simple
+records:
+
+```
+[
+  {"id": "CURI", "resource_markdown": "Resource description using **markdown**."},
+  ...
+]
+```
+
+Each record identifies one existing term by its CURI `id` and supplies
+the extra `resource_markdown` payload.  Markdown often contains
+newlines and these will be escaped in the JSON payload as `\n`, a
+backslash character followed by the character `n`.
+
+As soon as uploads are completed, the results can be reviewed by
+browsing the C2M2 vocabulary tables in the submission system itself.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ helper routine in the release submodule.
 
 `python -m cfde_deriva.release rebuild-submissions <release_id>`
 
-Command-like arguments:
+command-line arguments:
 
 - release_id is a `CFDE`.`release`.`id` key from the registry
 
@@ -272,7 +272,7 @@ is supplied in place of the `new` keyword:
 
 `python -m 'cfde_deriva.release' draft <release_id> [<description>]`
 
-Command-like arguments:
+command-line arguments:
 
 - release_id is a `CFDE`.`release`.`id` key from the registry
 - description is a short, human-readable string which will be visible in the release registry
@@ -291,7 +291,7 @@ built into a catalog using:
 
 `python -m 'cfde_deriva.release' build <release_id>`
 
-Command-like arguments:
+command-line arguments:
 
 - release_id is a `CFDE`.`release`.`id` key from the registry
 
@@ -331,7 +331,7 @@ data content.
 
 `python -m 'cfde_deriva.release' reconfigure <release_id>`
 
-Command-like arguments:
+command-line arguments:
 
 - release_id is a `CFDE`.`release`.`id` key from the registry
 
@@ -346,7 +346,7 @@ over time.
 
 `python -m 'cfde_deriva.release' publish <release_id>`
 
-Command-like arguments:
+command-line arguments:
 
 - release_id is a `CFDE`.`release`.`id` key from the registry
 
@@ -371,6 +371,20 @@ known terms.
 `python -m 'cfde_deriva.release' prune-favorites <release_id>`
 
 - release_id is a `CFDE`.`release`.`id` key from the registry
+
+#### Release refresh resource markdown
+
+The vocabulary term resource markdown content in a release can be
+refreshed to match the latest in the registry.
+
+`python -m cfde_deriva.release refresh-resources <release_id>`
+
+Command-line arguments:
+
+- release_id is a `CFDE`.`release.`id` key from the registry
+
+The release must already be in a content-ready or released
+state to allow refresh.
 
 #### Release purge
 

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -203,6 +203,22 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -274,6 +290,12 @@
                "*": [
                   "id",
                   "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
                   "description"
                ],
                "filter": {"and": [
@@ -342,6 +364,22 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -350,6 +388,81 @@
          "deriva": {
             "table_config": {
                "stable_key_columns": ["id"]
+            },
+            "source_definitions": {
+               "columns": true,
+               "fkeys": true,
+               "sources": {
+                  "S_core_fact": {
+                     "source": [
+                        {"inbound": ["CFDE", "core_fact_analysis_type_assay_type_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_analysis_type_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_biosample": {
+                     "markdown_name": "Biosample",
+                     "comment": "Biosamples referencing this analysis type.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "biosample_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_subject": {
+                     "markdown_name": "Subject",
+                     "comment": "Subjects referencing this analysis type.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "subject_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_collection": {
+                     "markdown_name": "Collection",
+                     "comment": "Cllections referencing this analysis type.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "collection_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_file": {
+                     "markdown_name": "File",
+                     "comment": "Files referencing this analysis type.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "file_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  }
+               }
+            },
+            "visible_columns": {
+               "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
+                  "description"
+               ],
+               "filter": {"and": [
+                  {"source": "id"},
+                  {"source": "name"},
+                  {"sourcekey": "S_collection"},
+                  {"sourcekey": "S_file"},
+                  {"sourcekey": "S_biosample"},
+                  {"sourcekey": "S_subject"}
+               ]}
+            },
+            "visible_foreign_keys": {
+               "*": [
+                  {"sourcekey": "S_file"}
+               ]
             }
          }
       },
@@ -409,6 +522,22 @@
                      "indexing_preferences": {
                         "btree": false,
                         "trgm": true
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
                      }
                   }
                }
@@ -480,6 +609,13 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "clade",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -565,6 +701,22 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -638,6 +790,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -723,6 +881,22 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -792,6 +966,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -877,6 +1057,22 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -946,6 +1142,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -1031,6 +1233,22 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -1111,6 +1329,12 @@
                "*": [
                   "id",
                   "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
                   "description"
                ],
                "filter": {"and": [
@@ -1181,6 +1405,22 @@
                      "indexing_preferences": {
                         "btree": false,
                         "trgm": true
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
                      }
                   }
                }
@@ -1265,6 +1505,12 @@
                   "name",
                   "description"
                ],
+               "compact": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
                "filter": {"and": [
                   {"source": "id"},
                   {"source": "name"},
@@ -1335,6 +1581,22 @@
                      "indexing_preferences": {
                         "btree": false,
                         "trgm": true
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
                      }
                   }
                }
@@ -1416,6 +1678,12 @@
                "*": [
                   "id",
                   "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
                   "description"
                ],
                "filter": {"and": [
@@ -1494,6 +1762,22 @@
                   "type": "integer",
                   "constraints": {
                      "required": true
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
                   }
                }
             ],
@@ -1575,7 +1859,8 @@
                   "id",
                   "name",
                   {"sourcekey": "S_compound"},
-                  "description"
+                  "description",
+                  "resource_markdown"
                ],
                "compact": [
                   "id",
@@ -1658,6 +1943,22 @@
                   "constraints": {
                      "required": true
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -1690,6 +1991,9 @@
                "columns": true,
                "fkeys": true,
                "sources": {
+                  "S_organism": {
+                     "source": [ {"outbound": ["CFDE", "gene_organism_fkey"]}, "nid" ]
+                  },
                   "S_phenotype": {
                      "markdown_name": "Phenotype",
                      "comment": "Phenotypes linked to this gene term.",
@@ -1746,6 +2050,13 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  {"sourcekey": "S_organism"},
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -1924,6 +2235,22 @@
                   "name": "description",
                   "description": "A human-readable description of this subject_role",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -1986,6 +2313,12 @@
                "*": [
                   "id",
                   "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
                   "description"
                ],
                "filter": {"and": [
@@ -2043,6 +2376,22 @@
                   "name": "description",
                   "description": "A human-readable description of this subject_granularity",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2105,6 +2454,12 @@
                "*": [
                   "id",
                   "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
                   "description"
                ],
                "filter": {"and": [
@@ -2162,6 +2517,22 @@
                   "name": "description",
                   "description": "A human-readable description of this sex",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2224,6 +2595,12 @@
                "*": [
                   "id",
                   "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
                   "description"
                ],
                "filter": {"and": [
@@ -2283,6 +2660,22 @@
                   "name": "description",
                   "description": "A human-readable description of this race",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2345,6 +2738,12 @@
                "*": [
                   "id",
                   "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
                   "description"
                ],
                "filter": {"and": [
@@ -2404,6 +2803,22 @@
                   "name": "description",
                   "description": "A human-readable description of this ethnicity",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information registered with the CFDE-CC",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2464,6 +2879,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"

--- a/cfde_deriva/configs/portal_prep/cfde-portal-prep.json
+++ b/cfde_deriva/configs/portal_prep/cfde-portal-prep.json
@@ -518,6 +518,12 @@
                   "name": "synonyms",
                   "description": "A list of human-readable synonyms for this term",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -569,6 +575,12 @@
                   "name": "synonyms",
                   "description": "A list of synonyms for this term as identified by the OBI metadata",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -627,6 +639,12 @@
                   "name": "synonyms",
                   "description": "A list of human-readable synonyms for this term",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -686,6 +704,12 @@
                   "name": "synonyms",
                   "description": "A list of human-readable synonyms for this term",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -745,6 +769,12 @@
                   "name": "synonyms",
                   "description": "A list of human-readable synonyms for this term",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -804,6 +834,12 @@
                   "name": "synonyms",
                   "description": "A list of human-readable synonyms for this term",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -864,6 +900,12 @@
                   "name": "synonyms",
                   "description": "A list of synonyms for this term as identified by the Disease Ontology metadata",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -915,6 +957,12 @@
                   "name": "synonyms",
                   "description": "A list of synonyms for this term as identified by the Human Phenotype Ontology metadata",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -966,6 +1014,12 @@
                   "name": "synonyms",
                   "description": "A list of synonyms for this PubChem CID",
                   "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -1025,6 +1079,12 @@
                   "constraints": {
                      "required": true
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -1093,6 +1153,12 @@
                   "constraints": {
                      "required": true
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -1189,6 +1255,12 @@
                   "name": "description",
                   "description": "A human-readable description of this subject_role",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -1234,6 +1306,12 @@
                   "name": "description",
                   "description": "A human-readable description of this subject_granularity",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -1276,6 +1354,12 @@
                   "name": "description",
                   "description": "A human-readable description of this sex term",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -1318,6 +1402,12 @@
                   "name": "description",
                   "description": "A human-readable description of this race term",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],
@@ -1360,6 +1450,12 @@
                   "name": "description",
                   "description": "A human-readable description of this ethnicity term",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
                }
             ],
             "missingValues": [ "" ],

--- a/cfde_deriva/configs/registry/cfde-registry-model.json
+++ b/cfde_deriva/configs/registry/cfde-registry-model.json
@@ -2007,6 +2007,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2039,6 +2040,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2089,6 +2096,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2121,6 +2129,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2175,6 +2189,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2207,6 +2222,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2260,6 +2281,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2292,6 +2314,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2404,6 +2432,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2436,6 +2465,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2497,6 +2532,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2529,6 +2565,13 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "clade",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2583,6 +2626,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2615,6 +2659,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2668,6 +2718,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2700,6 +2751,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2754,6 +2811,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2786,6 +2844,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2848,6 +2912,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2867,6 +2932,7 @@
             "foreignKeys": [
                {
                   "fields": "compound",
+                  "constraint_name": "substance_compound_fkey",
                   "reference": {
                      "resource": "compound",
                      "fields": "id"
@@ -2885,10 +2951,20 @@
                "columns": true,
                "fkeys": true,
                "sources": {
+                  "S_compound": {
+                     "source": [ {"outbound": ["CFDE", "substance_compound_fkey"]}, "RID" ]
+                  }
                }
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  {"sourcekey": "S_compound"},
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -2951,6 +3027,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -2970,6 +3047,7 @@
             "foreignKeys": [
                {
                   "fields": "organism",
+                  "constraint_name": "gene_organism_fkey",
                   "reference": {
                      "resource": "ncbi_taxonomy",
                      "fields": "id"
@@ -2988,10 +3066,20 @@
                "columns": true,
                "fkeys": true,
                "sources": {
+                  "S_organism": {
+                     "source": [ {"outbound": ["CFDE", "gene_organism_fkey"]}, "RID" ]
+                  }
                }
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  {"sourcekey": "S_organism"},
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -3035,6 +3123,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -3067,6 +3156,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -3107,6 +3202,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -3139,6 +3235,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -3179,6 +3281,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -3211,6 +3314,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -3251,6 +3360,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -3283,6 +3393,12 @@
             },
             "visible_columns": {
                "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
                   "id",
                   "name",
                   "description"
@@ -3449,6 +3565,7 @@
                },
                {
                   "name": "resource_markdown",
+                  "title": "Resources",
                   "description": "External resource information pre-formatted as markdown",
                   "type": "string",
                   "format": "markdown",
@@ -3483,7 +3600,8 @@
                "*": [
                   "id",
                   "name",
-                  "description"
+                  "description",
+                  "resource_markdown"
                ]
             },
             "visible_foreign_keys": {

--- a/cfde_deriva/configs/registry/cfde-registry-model.json
+++ b/cfde_deriva/configs/registry/cfde-registry-model.json
@@ -2004,6 +2004,21 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2069,6 +2084,21 @@
                      "indexing_preferences": {
                         "btree": false,
                         "trgm": true
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
                      }
                   }
                }
@@ -2142,6 +2172,21 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2210,6 +2255,21 @@
                      "indexing_preferences": {
                         "btree": false,
                         "trgm": true
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
                      }
                   }
                }
@@ -2341,6 +2401,21 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2419,6 +2494,21 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2488,6 +2578,21 @@
                      "indexing_preferences": {
                         "btree": false,
                         "trgm": true
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
                      }
                   }
                }
@@ -2560,6 +2665,21 @@
                         "trgm": true
                      }
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2629,6 +2749,21 @@
                      "indexing_preferences": {
                         "btree": false,
                         "trgm": true
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
                      }
                   }
                }
@@ -2709,6 +2844,21 @@
                   "type": "string",
                   "constraints": {
                      "required": true
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
                   }
                }
             ],
@@ -2798,6 +2948,21 @@
                   "constraints": {
                      "required": true
                   }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2867,6 +3032,21 @@
                   "name": "description",
                   "description": "A human-readable description of this subject_granularity",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2924,6 +3104,21 @@
                   "name": "description",
                   "description": "A human-readable description of this sex term",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -2981,6 +3176,21 @@
                   "name": "description",
                   "description": "A human-readable description of this race term",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -3038,6 +3248,21 @@
                   "name": "description",
                   "description": "A human-readable description of this ethnicity term",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],
@@ -3221,6 +3446,21 @@
                   "name": "description",
                   "description": "A human-readable description of this subject_role",
                   "type": "string"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
                }
             ],
             "missingValues": [ "" ],

--- a/cfde_deriva/datapackage.py
+++ b/cfde_deriva/datapackage.py
@@ -1661,6 +1661,7 @@ CREATE TABLE IF NOT EXISTS %(tname)s (
         # raise KeyError if we encounter an unmapped type!
         return {
             'text': 'text',
+            'markdown': 'text',
             'timestamptz': 'datetime',
             'date': 'date',
             'int8': 'int8',

--- a/cfde_deriva/datapackage.py
+++ b/cfde_deriva/datapackage.py
@@ -36,6 +36,9 @@ logger = logging.getLogger(__name__)
 if 'history_capture' not in tag:
     tag['history_capture'] = 'tag:isrd.isi.edu,2020:history-capture'
 
+if 'cfde_resource_src_rmt' not in tag:
+    tag['cfde_resource_src_rmt'] = 'tag:nih-cfde.org,2022:resource-src-rmt'
+
 # some special singleton strings...
 class _PackageDataName (object):
     def __init__(self, package, filename):

--- a/cfde_deriva/release.py
+++ b/cfde_deriva/release.py
@@ -473,6 +473,7 @@ class Release (object):
                 progress=progress.setdefault('etl', {}),
                 attach={'submission': self.ingest_sqlite_filename},
             )
+            Submission.download_resource_markdown_to_sqlite(self.registry, self.portal_prep_sqlite_filename)
             logger.info('Uploading all release content...')
             self.dump_progress(progress)
             Submission.upload_sqlite_content(catalog, self.portal_prep_sqlite_filename, progress=progress.setdefault('upload', {}))

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -426,6 +426,7 @@ class Submission (object):
 
             self.prepare_sqlite_derived_data(self.portal_prep_sqlite_filename, attach={"submission": self.ingest_sqlite_filename})
             self.record_vocab_usage(self.registry, self.portal_prep_sqlite_filename, self.datapackage_id)
+            self.download_resource_markdown_to_sqlite(self.registry, self.portal_prep_sqlite_filename)
 
             # this needs project_root from prepare_sqlite_derived_data...
             next_error_state = terms.cfde_registry_dp_status.content_error
@@ -1067,6 +1068,83 @@ LEFT OUTER JOIN project_root pr ON (d.project = pr.project);
             canon_dp = CfdeDataPackage(portal_schema_json)
             canon_dp.set_catalog(catalog)
             canon_dp.load_sqlite_tables(conn, onconflict='skip', table_done_callback=table_done_callback, table_error_callback=table_error_callback, progress=progress)
+
+    @classmethod
+    def download_resource_markdown_to_sqlite(cls, registry, portal_prep_filename):
+        """Retrieve resource_markdown content from registry into corresponding sqlite term records.
+
+        :param registry: The Registry instance for the submission system
+        :param portal_prep_filename: The sqlite3 file for the loaded and ETL'd submission content.
+        """
+        registry_dp = CfdeDataPackage(registry_schema_json)
+        registry_dp.set_catalog(registry._catalog)
+
+        with sqlite3.connect(portal_prep_filename) as conn:
+            cur = conn.cursor()
+            logger.info('Retrieving registry vocabulary resource_markdown content...')
+            for table in registry_dp.cat_cfde_schema.tables.values():
+                # skip tables that don't have right structure in registry
+                if {'id', 'name', 'description', 'resource_markdown'} - set(table.columns.elements.keys()):
+                    continue
+
+                # skip tables that don't have right structure in sqlite
+                cur.execute("""
+SELECT true
+FROM sqlite_master t
+JOIN pragma_table_info(%(tname)s) c ON (True)
+WHERE t.type = 'table'
+  AND t.name = %(tname)s
+  AND c.name = 'resource_markdown';
+""" % {
+    'tname': sql_literal(table.name),
+})
+                found = cur.fetchone()
+                if found is None:
+                    continue
+
+                cur.executescript("""
+CREATE TEMP TABLE IF NOT EXISTS temp_resource_markdown (
+  id text PRIMARY KEY,
+  resource_markdown text
+);
+DELETE FROM temp_resource_markdown;
+""")
+                def get_batches():
+                    after = ''
+                    while True:
+                        rows = registry_dp.catalog.get(
+                            '/attribute/CFDE:%s/!resource_markdown::null::/id,resource_markdown@sort(id)%s?limit=500' % (
+                                urlquote(table.name),
+                                after,
+                            )
+                        ).json()
+                        if rows:
+                            after = '@after(%s)' % (urlquote(rows[-1]['id']),)
+                            yield rows
+                        else:
+                            break
+
+                for batch in get_batches():
+                    cur.execute("""
+INSERT INTO temp_resource_markdown (id, resource_markdown)
+VALUES %(values)s;
+""" % {
+    'values': ', '.join([
+        '(%s, %s)' % (sql_literal(row['id']), sql_literal(row['resource_markdown']))
+        for row in batch
+    ])
+})
+                cur.execute("""
+UPDATE %(tname)s AS v
+SET resource_markdown = t.resource_markdown
+FROM temp_resource_markdown t
+WHERE v.id = t.id;
+""" % {
+    'tname': sql_identifier(table.name),
+})
+                cur.execute("SELECT count(*) FROM temp_resource_markdown;")
+                nrows = cur.fetchone()[0]
+                logger.info('Stored resource_markdown for %s rows of %r' % (nrows, table.name,))
 
     @classmethod
     def record_vocab_usage(cls, registry, portal_prep_filename, id):

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -416,6 +416,7 @@ class Submission (object):
             self.sqlite_datapackage_check(submission_schema_json, self.content_path, self.ingest_sqlite_filename, table_error_callback=dpt_error2)
             self.registry.update_datapackage(self.datapackage_id, status=terms.cfde_registry_dp_status.check_valid)
 
+            # TODO: remove this deprecated compatibility transform from code?
             next_error_state = terms.cfde_registry_dp_status.ops_error
             try:
                 self.transitional_etl_dcc_table(self.content_path, self.ingest_sqlite_filename, self.submitting_dcc_id)
@@ -1112,7 +1113,7 @@ LEFT OUTER JOIN project_root pr ON (d.project = pr.project);
                     'substance': '(SELECT s.nid, s.id, s.name, s.description, s.synonyms, c.id AS compound FROM substance s JOIN compound c ON (s.compound = c.nid))',
                     'gene': '(SELECT g.nid, g.id, g.name, g.description, g.synonyms, t.id AS organism FROM gene g JOIN ncbi_taxonomy t ON (g.organism = t.nid))',
                 },
-                skip_cols={'RID', 'RCT', 'RMT', 'RCB', 'RMB', 'nid'},
+                skip_cols={'RID', 'RCT', 'RMT', 'RCB', 'RMB', 'nid', 'resource_markdown'},
             )
             logger.info('Recording submission vocabulary usage in registry...')
             cur = conn.cursor()


### PR DESCRIPTION
Add simplified resource markdown support to vocabulary tables.

1. Each term has a nullable `resource_markdown` column
2. When populated, an extra "Resources" field is shown in the term's detailed view (in Chaise record page)
3. The authoritative resource markdown is stored in the vocab tables in the registry
4. An admin CLI is used to apply batches of resource info in JSON files to the registry's tables
5. Each submission or release build step retrieves latest registry resource info to augment local vocab tables
6. An admin CLI can be used to sync an already-built release catalog with the latest resource info in the registry
