### PR TITLE
Export optimization

### DIFF
--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -11777,8 +11777,8 @@
                         "outputs": [
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "personal_collection_file/F:=file/cf:=(core_fact)/i:=(cf:id_namespace)/p:=(cf:project)/pi:=(p:id_namespace)/ff:=left(cf:file_format)=(CFDE:file_format:nid)/fcf:=left(cf:compression_format)=(CFDE:file_format:nid)/dt:=left(cf:data_type)=(CFDE:data_type:nid)/at:=left(cf:assay_type)=(CFDE:assay_type:nid)/mt:=left(cf:mime_type)=(CFDE:mime_type:nid)/bc:=left(F:bundle_collection)=(CFDE:collection:nid)/left(core_fact)=(CFDE:core_fact:nid)/i3:=left(id_namespace)=(CFDE:id_namespace:nid)/$F/id_namespace:=i:id,local_id,project_id_namespace:=pi:id,project_local_id:=p:local_id,persistent_id,creation_time,size_in_bytes,uncompressed_size_in_bytes,sha256,md5,filename,file_format:=ff:id,compression_format:=fcf:id,data_type:=dt:id,assay_type:=at:id,mime_type:=mt:id,bundle_collection_id_namespace:=i3:id,bundle_collection_local_id:=bc:local_id"
+                                 "api": "entity",
+                                 "path": "personal_collection_file/CFDE:file/c2m2:file"
                               },
                               "destination": {
                                  "name": "file",

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -11915,6 +11915,439 @@
                }
             }
          }
+      },
+
+      {
+         "profile": "tabular-data-resource",
+         "resourceSchema": "raw",
+         "name": "collection",
+         "description": "Raw (original) C2M2 submission collection data",
+         "schema": {
+            "fields": [
+               {
+                  "name": "nid",
+                  "title": "Numeric ID",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  }
+               },
+               {
+                  "name": "id_namespace",
+                  "description": "A CFDE-cleared identifier representing the top-level data space containing this collection [part 1 of 2-component composite primary key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "local_id",
+                  "description": "An identifier representing this collection, unique within this id_namespace [part 2 of 2-component composite primary key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "persistent_id",
+                  "description": "A persistent, resolvable (not necessarily retrievable) URI or compact ID permanently attached to this collection",
+                  "type": "string"
+               },
+               {
+                  "name": "creation_time",
+                  "description": "An ISO 8601 -- RFC 3339 (subset)-compliant timestamp documenting this collection's creation time: YYYY-MM-DDTHH:MM:SS±NN:NN",
+                  "type": "datetime",
+                  "format": "any"
+               },
+               {
+                  "name": "abbreviation",
+                  "description": "A very short display label for this collection",
+                  "type": "string",
+                  "constraints": {
+                     "pattern": "^[a-zA-Z0-9_]+$"
+                  }
+               },
+               {
+                  "name": "name",
+                  "description": "A short, human-readable, machine-read-friendly label for this collection",
+                  "type": "string"
+               },
+               {
+                  "name": "description",
+                  "description": "A human-readable description of this collection",
+                  "type": "string"
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": [ "nid" ],
+            "foreignKeys": [
+               {
+                  "fields": "nid",
+                  "constraint_name": "collection_nid_fkey",
+                  "reference": {
+                     "resourceSchema": "CFDE",
+                     "resource": "collection",
+                     "fields": "nid"
+                  }
+               }
+            ]
+         },
+         "deriva": {
+            "indexing_preferences": {
+               "btree": false,
+               "trgm": false
+            }
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "resourceSchema": "raw",
+         "name": "file",
+         "description": "Raw (original) c2m2 submission file data",
+         "schema": {
+            "fields": [
+               {
+                  "name": "nid",
+                  "title": "Numeric ID",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  }
+               },
+               {
+                  "name": "id_namespace",
+                  "description": "A CFDE-cleared identifier representing the top-level data space containing this file [part 1 of 2-component composite primary key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "local_id",
+                  "description": "An identifier representing this file, unique within this id_namespace [part 2 of 2-component composite primary key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "project_id_namespace",
+                  "description": "The id_namespace of the primary project within which this file was created [part 1 of 2-component composite foreign key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "project_local_id",
+                  "description": "The local_id of the primary project within which this file was created [part 2 of 2-component composite foreign key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "persistent_id",
+                  "description": "A persistent, resolvable (not necessarily retrievable) URI or compact ID permanently attached to this file",
+                  "type": "string"
+               },
+               {
+                  "name": "creation_time",
+                  "description": "An ISO 8601 -- RFC 3339 (subset)-compliant timestamp documenting this file's creation time: YYYY-MM-DDTHH:MM:SS±NN:NN",
+                  "type": "datetime",
+                  "format": "any"
+               },
+               {
+                  "name": "size_in_bytes",
+                  "description": "The size of this file in bytes",
+                  "type": "integer"
+               },
+               {
+                  "name": "uncompressed_size_in_bytes",
+                  "description": "The total decompressed size in bytes of the contents of this file: null if this file is not compressed",
+                  "type": "integer"
+               },
+               {
+                  "name": "sha256",
+                  "description": "(preferred) SHA-256 checksum for this file [sha256, md5 cannot both be null]",
+                  "type": "string",
+                  "format": "binary"
+               },
+               {
+                  "name": "md5",
+                  "description": "(allowed) MD5 checksum for this file [sha256, md5 cannot both be null]",
+                  "type": "string",
+                  "format": "binary"
+               },
+               {
+                  "name": "filename",
+                  "description": "A filename with no prepended PATH information",
+                  "type": "string",
+                  "constraints": {
+                     "pattern": "^[^\/\\:]+$"
+                  }
+               },
+               {
+                  "name": "file_format",
+                  "description": "An EDAM CV term ID identifying the digital format of this file (e.g. TSV or FASTQ): if this file is compressed, this should be its _uncompressed_ format",
+                  "type": "string"
+               },
+               {
+                  "name": "compression_format",
+                  "description": "An EDAM CV term ID identifying the compression format of this file (e.g. gzip or bzip2): null if this file is not compressed",
+                  "type": "string"
+               },
+               {
+                  "name": "data_type",
+                  "description": "An EDAM CV term ID identifying the type of information stored in this file (e.g. RNA sequence reads): null if is_bundle is set to true",
+                  "type": "string"
+               },
+               {
+                  "name": "assay_type",
+                  "description": "An OBI CV term ID describing the type of experiment that generated the results summarized by this file",
+                  "type": "string"
+               },
+               {
+                  "name": "analysis_type",
+                  "description": "An OBI CV term ID describing the type of analytic operation that generated this file",
+                  "type": "string"
+               },
+               {
+                  "name": "mime_type",
+                  "description": "A MIME type describing this file",
+                  "type": "string"
+               },
+               {
+                  "name": "bundle_collection_id_namespace",
+                  "description": "If this file is a bundle encoding more than one sub-file, this field gives the id_namespace of a collection listing the bundle's sub-file contents. Null otherwise.",
+                  "type": "string"
+               },
+               {
+                  "name": "bundle_collection_local_id",
+                  "description": "If this file is a bundle encoding more than one sub-file, this field gives the local_id of a collection listing the bundle's sub-file contents. Null otherwise.",
+                  "type": "string"
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": [ "nid" ],
+            "foreignKeys": [
+               {
+                  "fields": "nid",
+                  "constraint_name": "file_nid_fkey",
+                  "reference": {
+                     "resourceSchema": "CFDE",
+                     "resource": "file",
+                     "fields": "nid"
+                  }
+               }
+            ]
+         },
+         "deriva": {
+            "indexing_preferences": {
+               "btree": false,
+               "trgm": false
+            }
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "resourceSchema": "raw",
+         "name": "biosample",
+         "title": "biosample",
+         "description": "Raw (original) c2m2 submission biosample data",
+         "schema": {
+            "fields": [
+               {
+                  "name": "nid",
+                  "title": "Numeric ID",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  }
+               },
+               {
+                  "name": "id_namespace",
+                  "description": "A CFDE-cleared identifier representing the top-level data space containing this biosample [part 1 of 2-component composite primary key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "local_id",
+                  "description": "An identifier representing this biosample, unique within this id_namespace [part 2 of 2-component composite primary key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "project_id_namespace",
+                  "description": "The id_namespace of the primary project within which this biosample was created [part 1 of 2-component composite foreign key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "project_local_id",
+                  "description": "The local_id of the primary project within which this biosample was created [part 2 of 2-component composite foreign key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "persistent_id",
+                  "description": "A persistent, resolvable (not necessarily retrievable) URI or compact ID permanently attached to this biosample",
+                  "type": "string"
+               },
+               {
+                  "name": "creation_time",
+                  "description": "An ISO 8601 -- RFC 3339 (subset)-compliant timestamp documenting this biosample's creation time: YYYY-MM-DDTHH:MM:SS±NN:NN",
+                  "type": "datetime",
+                  "format": "any"
+               },
+               {
+                  "name": "assay_type",
+                  "description": "An OBI CV term ID describing the type of experiment that generated this biosample",
+                  "type": "string"
+               },
+               {
+                  "name": "anatomy",
+                  "description": "An UBERON CV term ID used to locate the origin of this biosample within the physiology of its source or host organism",
+                  "type": "string"
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": [ "nid" ],
+            "foreignKeys": [
+               {
+                  "fields": "nid",
+                  "constraint_name": "biosample_nid_fkey",
+                  "reference": {
+                     "resourceSchema": "CFDE",
+                     "resource": "biosample",
+                     "fields": "nid"
+                  }
+               }
+            ]
+         },
+         "deriva": {
+            "indexing_preferences": {
+               "btree": false,
+               "trgm": false
+            }
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "resourceSchema": "raw",
+         "name": "subject",
+         "title": "subject",
+         "description": "Raw (original) c2m2 submission subject data",
+         "schema": {
+            "fields": [
+               {
+                  "name": "nid",
+                  "title": "Numeric ID",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  }
+               },
+               {
+                  "name": "id_namespace",
+                  "description": "A CFDE-cleared identifier representing the top-level data space containing this subject [part 1 of 2-component composite primary key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "local_id",
+                  "description": "An identifier representing this subject, unique within this id_namespace [part 2 of 2-component composite primary key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "project_id_namespace",
+                  "description": "The id_namespace of the primary project within which this subject was studied [part 1 of 2-component composite foreign key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "project_local_id",
+                  "description": "The local_id of the primary project within which this subject was studied [part 2 of 2-component composite foreign key]",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "persistent_id",
+                  "description": "A persistent, resolvable (not necessarily retrievable) URI or compact ID permanently attached to this subject",
+                  "type": "string"
+               },
+               {
+                  "name": "creation_time",
+                  "description": "An ISO 8601 -- RFC 3339 (subset)-compliant timestamp documenting this subject record's creation time: YYYY-MM-DDTHH:MM:SS±NN:NN",
+                  "type": "datetime",
+                  "format": "any"
+               },
+               {
+                  "name": "granularity",
+                  "description": "A CFDE CV term categorizing this subject by multiplicity",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "sex",
+                  "description": "The sex of this subject",
+                  "type": "string"
+               },
+               {
+                  "name": "ethnicity",
+                  "description": "The ethnicity of this subject",
+                  "type": "string"
+               },
+               {
+                  "name": "age_at_enrollment",
+                  "description": "The age in years (with a fixed precision of two digits past the decimal point) of this subject when they were first enrolled in the primary project within which they were studied",
+                  "type": "number"
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": [ "nid" ],
+            "foreignKeys": [
+               {
+                  "fields": "nid",
+                  "constraint_name": "subject_nid_fkey",
+                  "reference": {
+                     "resourceSchema": "CFDE",
+                     "resource": "subject",
+                     "fields": "nid"
+                  }
+               }
+            ]
+         },
+         "deriva": {
+            "indexing_preferences": {
+               "btree": false,
+               "trgm": false
+            }
+         }
       }
+
    ]
 }

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -3736,7 +3736,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "(nid)=(raw:collection:nid)"
+                                 "path": "c2m2:collection"
                               },
                               "destination": {
                                  "name": "collection",
@@ -3745,8 +3745,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:collection_disease:collection)/d:=(disease)/$a/collection_id_namespace:=i:id,collection_local_id:=M:local_id,disease:=d:id"
+                                 "api": "entity",
+                                 "path": "CFDE:collection_disease/c2m2:collection_disease"
                               },
                               "destination": {
                                  "name": "collection_disease",
@@ -3755,8 +3755,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:collection_phenotype:collection)/p:=(phenotype)/$a/collection_id_namespace:=i:id,collection_local_id:=M:local_id,phenotype:=p:id"
+                                 "api": "entity",
+                                 "path": "CFDE:collection_phenotype/c2m2:collection_phenotype"
                               },
                               "destination": {
                                  "name": "collection_phenotype",
@@ -3765,8 +3765,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/p:=(leader_project)/i:=(id_namespace)/$p/id_namespace:=i:id,local_id,persistent_id,creation_time,abbreviation,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/(leader_project)=(c2m2:project:nid)"
                               },
                               "destination": {
                                  "name": "project",
@@ -3775,8 +3775,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/a:=(leader_project)=(CFDE:project_in_project:child_project)/pp:=(parent_project)/ppi:=(id_namespace)/cp:=(a:child_project)/cpi:=(id_namespace)/$a/parent_project_id_namespace:=ppi:id,parent_project_local_id:=pp:local_id,child_project_id_namespace:=cpi:id,child_project_local_id:=cp:local_id"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/(leader_project)=(CFDE:project_in_project:child_project)/c2m2:project_in_project"
                               },
                               "destination": {
                                  "name": "project_in_project",
@@ -3786,7 +3786,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "CFDE:file_in_collection/(file)/(nid)=(raw:file:nid)"
+                                 "path": "CFDE:file_in_collection/(file)=(c2m2:file:nid)"
                               },
                               "destination": {
                                  "name": "file",
@@ -3795,8 +3795,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_file_format/CFDE:file_format/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_file_format/(file_format)=(c2m2:file_format:nid)"
                               },
                               "destination": {
                                  "name": "file_format",
@@ -3805,8 +3805,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_data_type/CFDE:data_type/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_data_type/(data_type)=(c2m2:data_type:nid)"
                               },
                               "destination": {
                                  "name": "data_type",
@@ -3815,8 +3815,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_assay_type/CFDE:assay_type/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_assay_type/(assay_type)=(c2m2:assay_type:nid)"
                               },
                               "destination": {
                                  "name": "assay_type",
@@ -3826,7 +3826,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "CFDE:biosample_in_collection/(biosample)/(nid)=(raw:biosample:nid)"
+                                 "path": "CFDE:biosample_in_collection/(biosample)=(c2m2:biosample:nid)"
                               },
                               "destination": {
                                  "name": "biosample",
@@ -3835,8 +3835,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_anatomy/CFDE:anatomy/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_anatomy/(anatomy)=(c2m2:anatomy:nid)"
                               },
                               "destination": {
                                  "name": "anatomy",
@@ -3845,8 +3845,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_disease/CFDE:disease/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_disease/(disease)=(c2m2:disease:nid)"
                               },
                               "destination": {
                                  "name": "disease",
@@ -3855,8 +3855,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_phenotype/CFDE:phenotype/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_phenotype/(phenotype)=(c2m2:phenotype:nid)"
                               },
                               "destination": {
                                  "name": "phenotype",
@@ -3865,8 +3865,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(gene_fact)/CFDE:gene_fact_gene/CFDE:gene/id,name,description"
+                                 "api": "entity",
+                                 "path": "(gene_fact)/CFDE:gene_fact_gene/(gene)=(c2m2:gene:nid)"
                               },
                               "destination": {
                                  "name": "gene",
@@ -3875,8 +3875,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/CFDE:substance/id,name,description"
+                                 "api": "entity",
+                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/(substance)=(c2m2:substance:nid)"
                               },
                               "destination": {
                                  "name": "substance",
@@ -3885,8 +3885,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/CFDE:substance/CFDE:compound/id,name,description"
+                                 "api": "entity",
+                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_compound/(compound)=(c2m2:compound:nid)"
                               },
                               "destination": {
                                  "name": "compound",
@@ -3895,8 +3895,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_in_collection/b:=(biosample)/(core_fact)/i:=(id_namespace)/$b/a:=(CFDE:biosample_disease:biosample)/d:=(disease)/at:=(a:association_type)=(disease_association_type:nid)/$a/biosample_id_namespace:=i:id,biosample_local_id:=b:local_id,association_type:=at:id,disease:=d:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_in_collection/(biosample)=(CFDE:biosample_disease:biosample)/c2m2:biosample_disease"
                               },
                               "destination": {
                                  "name": "biosample_disease",
@@ -3905,8 +3905,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_in_collection/b:=(biosample)/(core_fact)/i:=(id_namespace)/$b/a:=(CFDE:biosample_gene:biosample)/g:=(gene)/$a/biosample_id_namespace:=i:id,biosample_local_id:=b:local_id,gene:=g:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_in_collection/(biosample)=(CFDE:biosample_gene:biosample)/c2m2:biosample_gene"
                               },
                               "destination": {
                                  "name": "biosample_gene",
@@ -3915,8 +3915,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_in_collection/b:=(biosample)/(core_fact)/i:=(id_namespace)/$b/a:=(CFDE:biosample_substance:biosample)/s:=(substance)/$a/biosample_id_namespace:=i:id,biosample_local_id:=b:local_id,substance:=s:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_in_collection/(biosample)=(CFDE:biosample_substance:biosample)/c2m2:biosample_substance"
                               },
                               "destination": {
                                  "name": "biosample_substance",
@@ -3925,8 +3925,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_in_collection/b:=(biosample)/(core_fact)/i1:=(id_namespace)/$b/a:=CFDE:biosample_from_subject/s:=CFDE:subject/(core_fact)/i2:=(id_namespace)/$a/biosample_id_namespace:=i1:id,biosample_local_id:=b:local_id,subject_id_namespace:=i2:id,subject_local_id:=s:local_id,age_at_sampling"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_in_collection/(biosample)=(CFDE:biosample_from_subject:biosample)/c2m2:biosample_from_subject"
                               },
                               "destination": {
                                  "name": "biosample_from_subject",
@@ -3936,7 +3936,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "CFDE:subject_in_collection/(subject)/(nid)=(raw:subject:nid)"
+                                 "path": "CFDE:subject_in_collection/(subject)=(c2m2:subject:nid)"
                               },
                               "destination": {
                                  "name": "subject",
@@ -3945,8 +3945,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_subject_granularity/CFDE:subject_granularity/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_subject_granularity/(subject_granularity)=(c2m2:subject_granularity:nid)"
                               },
                               "destination": {
                                  "name": "subject_granularity",
@@ -3955,8 +3955,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:subject_in_collection/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_role_taxonomy:subject)/r:=(a:role)/t:=(a:taxon)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,role_id:=r:id,taxonomy_id:=t:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_in_collection/(subject)=(CFDE:subject_role_taxonomy:subject)/c2m2:subject_role_taxonomy"
                               },
                               "destination": {
                                  "name": "subject_role_taxonomy",
@@ -3965,8 +3965,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_subject_role/CFDE:subject_role/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_subject_role/(subject_role)=(c2m2:subject_role:nid)"
                               },
                               "destination": {
                                  "name": "subject_role",
@@ -3975,8 +3975,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_ncbi_taxonomy/CFDE:ncbi_taxonomy/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_ncbi_taxonomy/(ncbi_taxon)=(c2m2:ncbi_taxonomy:nid)"
                               },
                               "destination": {
                                  "name": "ncbi_taxonomy",
@@ -3985,8 +3985,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_sex/CFDE:sex/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_sex/(sex)=(c2m2:sex:nid)"
                               },
                               "destination": {
                                  "name": "sex",
@@ -3995,8 +3995,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_race/CFDE:race/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_race/(race)=(c2m2:race:nid)"
                               },
                               "destination": {
                                  "name": "race",
@@ -4005,8 +4005,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_ethnicity/CFDE:ethnicity/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_ethnicity/(ethnicity)=(c2m2:ethnicity:nid)"
                               },
                               "destination": {
                                  "name": "ethnicity",
@@ -4015,8 +4015,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:subject_in_collection/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_race:subject)/v:=(race)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,race:=v:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_in_collection/(subject)=(CFDE:subject_race:subject)/c2m2:subject_race"
                               },
                               "destination": {
                                  "name": "subject_race",
@@ -4025,8 +4025,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:subject_in_collection/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_substance:subject)/v:=(substance)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,substance:=v:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_in_collection/(subject)=(CFDE:subject_substance:subject)/c2m2:subject_substance"
                               },
                               "destination": {
                                  "name": "subject_substance",
@@ -4035,8 +4035,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:subject_in_collection/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_disease:subject)/d:=(disease)/at:=(a:association_type)=(CFDE:disease_association_type:nid)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,association_type:=at:id,disease:=d:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_in_collection/(subject)=(CFDE:subject_disease:subject)/c2m2:subject_disease"
                               },
                               "destination": {
                                  "name": "subject_disease",
@@ -4045,8 +4045,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:subject_in_collection/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_phenotype:subject)/p:=(phenotype)/at:=(a:association_type)=(CFDE:phenotype_association_type:nid)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,association_type:=at:id,phenotype:=p:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_in_collection/(subject)=(CFDE:subject_phenotype:subject)/c2m2:subject_phenotype"
                               },
                               "destination": {
                                  "name": "subject_phenotype",
@@ -4633,7 +4633,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "(nid)=(raw:file:nid)"
+                                 "path": "c2m2:file"
                               },
                               "destination": {
                                  "name": "file",
@@ -4642,8 +4642,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "cf:=(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/p:=(leader_project)=(CFDE:project:nid)/i:=(id_namespace)=(CFDE:id_namespace:nid)/$p/id_namespace:=i:id,local_id,persistent_id,creation_time,abbreviation,name,description"
+                                 "api": "entity",
+                                 "path": "cf:=(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/p:=(leader_project)=(c2m2:project:nid)"
                               },
                               "destination": {
                                  "name": "project",
@@ -4652,8 +4652,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "cf:=(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/a:=(leader_project)=(CFDE:project_in_project:child_project)/pp:=(a:parent_project)/ppi:=(id_namespace)/cp:=(a:child_project)/cpi:=(id_namespace)/parent_project_id_namespace:=ppi:id,parent_project_local_id:=pp:local_id,child_project_id_namespace:=cpi:id,child_project_local_id:=cp:local_id"
+                                 "api": "entity",
+                                 "path": "cf:=(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/(leader_project)=(CFDE:project_in_project:child_project)/c2m2:project_in_project"
                               },
                               "destination": {
                                  "name": "project_in_project",
@@ -4662,8 +4662,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_file_format/CFDE:file_format/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_file_format/(file_format)=(c2m2:file_format:nid)"
                               },
                               "destination": {
                                  "name": "file_format",
@@ -4672,8 +4672,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_data_type/CFDE:data_type/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_data_type/(data_type)=(c2m2:data_type:nid)"
                               },
                               "destination": {
                                  "name": "data_type",
@@ -4682,8 +4682,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_assay_type/CFDE:assay_type/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_assay_type/(assay_type)=(c2m2:assay_type:nid)"
                               },
                               "destination": {
                                  "name": "assay_type",
@@ -4693,7 +4693,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "CFDE:file_describes_biosample/(biosample)/(nid)=(raw:biosample:nid)"
+                                 "path": "CFDE:file_describes_biosample/(biosample)=(c2m2:biosample:nid)"
                               },
                               "destination": {
                                  "name": "biosample",
@@ -4702,8 +4702,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_anatomy/CFDE:anatomy/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_anatomy/(anatomy)=(c2m2:anatomy:nid)"
                               },
                               "destination": {
                                  "name": "anatomy",
@@ -4712,8 +4712,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_disease/CFDE:disease/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_disease/(disease)=(c2m2:disease:nid)"
                               },
                               "destination": {
                                  "name": "disease",
@@ -4722,8 +4722,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(gene_fact)/CFDE:gene_fact_gene/CFDE:gene/id,name,description"
+                                 "api": "entity",
+                                 "path": "(gene_fact)/CFDE:gene_fact_gene/(gene)=(c2m2:gene:nid)"
                               },
                               "destination": {
                                  "name": "gene",
@@ -4732,8 +4732,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/CFDE:substance/id,name,description"
+                                 "api": "entity",
+                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/(substance)=(c2m2:substance:nid)"
                               },
                               "destination": {
                                  "name": "substance",
@@ -4742,8 +4742,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/CFDE:substance/CFDE:compound/id,name,description"
+                                 "api": "entity",
+                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_compound/(compound)=(c2m2:compound:nid)"
                               },
                               "destination": {
                                  "name": "compound",
@@ -4752,8 +4752,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_biosample/b:=(biosample)/(core_fact)/i:=(id_namespace)/$b/a:=(CFDE:biosample_disease:biosample)/d:=(disease)/at:=(a:association_type)=(disease_association_type:nid)/$a/biosample_id_namespace:=i:id,biosample_local_id:=b:local_id,association_type:=at:id,disease:=d:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_biosample/(biosample)=(CFDE:biosample_disease:biosample)/c2m2:biosample_disease"
                               },
                               "destination": {
                                  "name": "biosample_disease",
@@ -4762,8 +4762,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_biosample/b:=(biosample)/(core_fact)/i:=(id_namespace)/$b/a:=(CFDE:biosample_gene:biosample)/g:=(gene)/$a/biosample_id_namespace:=i:id,biosample_local_id:=b:local_id,gene:=g:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_biosample/(biosample)=(CFDE:biosample_gene:biosample)/c2m2:biosample_gene"
                               },
                               "destination": {
                                  "name": "biosample_gene",
@@ -4772,8 +4772,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_biosample/b:=(biosample)/(core_fact)/i:=(id_namespace)/$b/a:=(CFDE:biosample_substance:biosample)/s:=(substance)/$a/biosample_id_namespace:=i:id,biosample_local_id:=b:local_id,substance:=s:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_biosample/(biosample)=(CFDE:biosample_substance:biosample)/c2m2:biosample_substance"
                               },
                               "destination": {
                                  "name": "biosample_substance",
@@ -4782,8 +4782,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_biosample/b:=(biosample)/(core_fact)/i1:=(id_namespace)/$b/a:=CFDE:biosample_from_subject/s:=CFDE:subject/(core_fact)/i2:=(id_namespace)/$a/biosample_id_namespace:=i1:id,biosample_local_id:=b:local_id,subject_id_namespace:=i2:id,subject_local_id:=s:local_id,age_at_sampling"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_biosample/(biosample)=(CFDE:biosample_from_subject:biosample)/c2m2:biosample_from_subject"
                               },
                               "destination": {
                                  "name": "biosample_from_subject",
@@ -4793,7 +4793,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "CFDE:file_describes_subject/(subject)/(nid)=(raw:subject:nid)"
+                                 "path": "CFDE:file_describes_subject/(subject)=(c2m2:subject:nid)"
                               },
                               "destination": {
                                  "name": "subject",
@@ -4802,8 +4802,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_subject_granularity/CFDE:subject_granularity/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_subject_granularity/(subject_granularity)=(c2m2:subject_granularity:nid)"
                               },
                               "destination": {
                                  "name": "subject_granularity",
@@ -4813,8 +4813,8 @@
                            {
 
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_subject/s:=(subject)/a:=CFDE:subject_role_taxonomy/(s:core_fact)/i:=(id_namespace)/r:=(a:role)/t:=(a:taxon)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,role_id:=r:id,taxonomy_id:=t:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_subject/(subject)/CFDE:subject_role_taxonomy/c2m2:subject_role_taxonomy"
                               },
                               "destination": {
                                  "name": "subject_role_taxonomy",
@@ -4823,8 +4823,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_subject_role/CFDE:subject_role/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_subject_role/(subject_role)=(c2m2:subject_role:nid)"
                               },
                               "destination": {
                                  "name": "subject_role",
@@ -4833,8 +4833,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_ncbi_taxonomy/CFDE:ncbi_taxonomy/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_ncbi_taxonomy/(ncbi_taxon)=(c2m2:ncbi_taxonomy:nid)"
                               },
                               "destination": {
                                  "name": "ncbi_taxonomy",
@@ -4843,8 +4843,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_sex/CFDE:sex/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_sex/(sex)=(c2m2:sex:nid)"
                               },
                               "destination": {
                                  "name": "sex",
@@ -4853,8 +4853,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_race/CFDE:race/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_race/(race)=(c2m2:race:nid)"
                               },
                               "destination": {
                                  "name": "race",
@@ -4863,8 +4863,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_ethnicity/CFDE:ethnicity/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_ethnicity/(ethnicity)=(c2m2:ethnicity:nid)"
                               },
                               "destination": {
                                  "name": "ethnicity",
@@ -4873,8 +4873,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_subject/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_race:subject)/v:=(race)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,race:=v:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_subject/(subject)=(CFDE:subject_race:subject)/c2m2:subject_race"
                               },
                               "destination": {
                                  "name": "subject_race",
@@ -4883,8 +4883,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_subject/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_substance:subject)/v:=(substance)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,substance:=v:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_subject/(subject)=(CFDE:subject_substance:subject)/c2m2:subject_substance"
                               },
                               "destination": {
                                  "name": "subject_substance",
@@ -4893,8 +4893,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_subject/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_disease:subject)/d:=(disease)/at:=(a:association_type)=(disease_association_type:nid)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,association_type:=at:id,disease:=d:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_subject/(subject)=(CFDE:subject_disease:subject)/c2m2:subject_disease"
                               },
                               "destination": {
                                  "name": "subject_disease",
@@ -4903,8 +4903,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_subject/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_phenotype:subject)/p:=(phenotype)/at:=(a:association_type)=(CFDE:phenotype_association_type:nid)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,association_type:=at:id,phenotype:=p:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_subject/(subject)=(CFDE:subject_phenotype:subject)/c2m2:subject_phenotype"
                               },
                               "destination": {
                                  "name": "subject_phenotype",
@@ -5538,7 +5538,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "(nid)=(raw:biosample:nid)"
+                                 "path": "c2m2:biosample"
                               },
                               "destination": {
                                  "name": "biosample",
@@ -5547,8 +5547,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/p:=(leader_project)/i:=(id_namespace)/$p/id_namespace:=i:id,local_id,persistent_id,creation_time,abbreviation,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/(leader_project)=(c2m2:project:nid)"
                               },
                               "destination": {
                                  "name": "project",
@@ -5557,8 +5557,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/a:=(leader_project)=(CFDE:project_in_project:child_project)/pp:=(a:parent_project)/ppi:=(id_namespace)/cp:=(a:child_project)/cpi:=(id_namespace)/$a/parent_project_id_namespace:=ppi:id,parent_project_local_id:=pp:local_id,child_project_id_namespace:=cpi:id,child_project_local_id:=cp:local_id"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_project/(project)=(CFDE:project_in_project_transitive:member_project)/(leader_project)=(CFDE:project_in_project:child_project)/c2m2:project_in_project"
                               },
                               "destination": {
                                  "name": "project_in_project",
@@ -5567,8 +5567,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_assay_type/CFDE:assay_type/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_assay_type/(assay_type)=(c2m2:assay_type:nid)"
                               },
                               "destination": {
                                  "name": "assay_type",
@@ -5577,8 +5577,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_anatomy/CFDE:anatomy/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_anatomy/(anatomy)=(c2m2:anatomy:nid)"
                               },
                               "destination": {
                                  "name": "anatomy",
@@ -5587,8 +5587,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_disease/CFDE:disease/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_disease/(disease)=(c2m2:disease:nid)"
                               },
                               "destination": {
                                  "name": "disease",
@@ -5597,8 +5597,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(gene_fact)/CFDE:gene_fact_gene/CFDE:gene/id,name,description"
+                                 "api": "entity",
+                                 "path": "(gene_fact)/CFDE:gene_fact_gene/(gene)=(c2m2:gene:nid)"
                               },
                               "destination": {
                                  "name": "gene",
@@ -5607,8 +5607,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/CFDE:substance/id,name,description"
+                                 "api": "entity",
+                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/(substance)=(c2m2:substance:nid)"
                               },
                               "destination": {
                                  "name": "substance",
@@ -5617,8 +5617,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_substance/CFDE:substance/CFDE:compound/id,name,description"
+                                 "api": "entity",
+                                 "path": "(pubchem_fact)/CFDE:pubchem_fact_compound/(compound)=(c2m2:compound:nid)"
                               },
                               "destination": {
                                  "name": "compound",
@@ -5627,8 +5627,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:biosample_disease:biosample)/d:=(disease)/at:=(a:association_type)=(disease_association_type:nid)/$a/biosample_id_namespace:=i:id,biosample_local_id:=M:local_id,association_type:=at:id,disease:=d:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_disease/c2m2:biosample_disease"
                               },
                               "destination": {
                                  "name": "biosample_disease",
@@ -5637,8 +5637,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:biosample_gene:biosample)/g:=(gene)/$a/biosample_id_namespace:=i:id,biosample_local_id:=M:local_id,gene:=g:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_gene/c2m2:biosample_gene"
                               },
                               "destination": {
                                  "name": "biosample_gene",
@@ -5647,8 +5647,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:biosample_substance:biosample)/s:=(substance)/$a/biosample_id_namespace:=i:id,biosample_local_id:=M:local_id,substance:=s:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_substance/c2m2:biosample_substance"
                               },
                               "destination": {
                                  "name": "biosample_substance",
@@ -5657,8 +5657,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i1:=(id_namespace)/$M/a:=CFDE:biosample_from_subject/s:=CFDE:subject/(core_fact)/i2:=(id_namespace)/$a/biosample_id_namespace:=i1:id,biosample_local_id:=M:local_id,subject_id_namespace:=i2:id,subject_local_id:=s:local_id,age_at_sampling"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_from_subject/c2m2:biosample_from_subject"
                               },
                               "destination": {
                                  "name": "biosample_from_subject",
@@ -5668,7 +5668,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "CFDE:biosample_from_subject/(subject)/(nid)=(raw:subject:nid)"
+                                 "path": "CFDE:biosample_from_subject/(subject)=(c2m2:subject:nid)"
                               },
                               "destination": {
                                  "name": "subject",
@@ -5677,8 +5677,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_subject_granularity/CFDE:subject_granularity/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_subject_granularity/(subject_granularity)=(c2m2:subject_granularity:nid)"
                               },
                               "destination": {
                                  "name": "subject_granularity",
@@ -5688,8 +5688,8 @@
                            {
 
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_from_subject/s:=(subject)/a:=CFDE:subject_role_taxonomy/(s:core_fact)/i:=(id_namespace)/r:=(a:role)/t:=(a:taxon)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,role_id:=r:id,taxonomy_id:=t:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_from_subject/(subject)=(CFDE:subject_role_taxonomy:subject)/c2m2:subject_role_taxonomy"
                               },
                               "destination": {
                                  "name": "subject_role_taxonomy",
@@ -5698,8 +5698,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_subject_role/CFDE:subject_role/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_subject_role/(subject_role)=(c2m2:subject_role:nid)"
                               },
                               "destination": {
                                  "name": "subject_role",
@@ -5708,8 +5708,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_ncbi_taxonomy/CFDE:ncbi_taxonomy/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_ncbi_taxonomy/(ncbi_taxon)=(c2m2:ncbi_taxonomy:nid)"
                               },
                               "destination": {
                                  "name": "ncbi_taxonomy",
@@ -5718,8 +5718,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_sex/CFDE:sex/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_sex/(sex)=(c2m2:sex:nid)"
                               },
                               "destination": {
                                  "name": "sex",
@@ -5728,8 +5728,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_race/CFDE:race/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_race/(race)=(c2m2:race:nid)"
                               },
                               "destination": {
                                  "name": "race",
@@ -5738,8 +5738,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_ethnicity/CFDE:ethnicity/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_ethnicity/(ethnicity)=(c2m2:ethnicity:nid)"
                               },
                               "destination": {
                                  "name": "ethnicity",
@@ -5748,8 +5748,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_from_subject/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_race:subject)/v:=(race)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,race:=v:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_from_subject/(subject)=(CFDE:subject_race:subject)/c2m2:subject_race"
                               },
                               "destination": {
                                  "name": "subject_race",
@@ -5758,8 +5758,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_from_subject/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_substance:subject)/v:=(substance)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,substance:=v:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_from_subject/(subject)=(CFDE:subject_substance:subject)/c2m2:subject_substance"
                               },
                               "destination": {
                                  "name": "subject_substance",
@@ -5768,8 +5768,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_from_subject/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_disease:subject)/d:=(disease)/at:=(a:association_type)=(disease_association_type:nid)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,association_type:=at:id,disease:=d:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_from_subject/(subject)=(CFDE:subject_disease:subject)/c2m2:subject_disease"
                               },
                               "destination": {
                                  "name": "subject_disease",
@@ -5778,8 +5778,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_from_subject/s:=(subject)/(core_fact)/i:=(id_namespace)/$s/a:=(CFDE:subject_phenotype:subject)/p:=(phenotype)/at:=(a:association_type)=(CFDE:phenotype_association_type:nid)/$a/subject_id_namespace:=i:id,subject_local_id:=s:local_id,association_type:=at:id,phenotype:=p:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_from_subject/(subject)=(CFDE:subject_phenotype:subject)/c2m2:subject_phenotype"
                               },
                               "destination": {
                                  "name": "subject_phenotype",
@@ -6325,7 +6325,7 @@
                            {
                               "source": {
                                  "api": "entity",
-                                 "path": "(nid)=(raw:subject:nid)"
+                                 "path": "c2m2:subject"
                               },
                               "destination": {
                                  "name": "subject",
@@ -6334,8 +6334,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/(project)=(CFDE:project_in_project_transitive:member_project)/p:=(leader_project)/i:=(id_namespace)/$p/id_namespace:=i:id,local_id,persistent_id,creation_time,abbreviation,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/(project)=(CFDE:project_in_project_transitive:member_project)/(leader_project)=(c2m2:project:nid)"
                               },
                               "destination": {
                                  "name": "project",
@@ -6344,8 +6344,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/(project)=(CFDE:project_in_project_transitive:member_project)/a:=(leader_project)=(CFDE:project_in_project:child_project)/pp:=(parent_project)/ppi:=(id_namespace)/cp:=(a:child_project)/cpi:=(id_namespace)/$a/parent_project_id_namespace:=ppi:id,parent_project_local_id:=pp:local_id,child_project_id_namespace:=cpi:id,child_project_local_id:=cp:local_id"
+                                 "api": "entity",
+                                 "path": "(core_fact)/(project)=(CFDE:project_in_project_transitive:member_project)/(leader_project)=(CFDE:project_in_project:child_project)/c2m2:project_in_project"
                               },
                               "destination": {
                                  "name": "project_in_project",
@@ -6354,8 +6354,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/(subject_granularity)/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/(subject_granularity)=(c2m2:subject_granularity:nid)"
                               },
                               "destination": {
                                  "name": "subject_granularity",
@@ -6365,8 +6365,8 @@
                            {
 
                               "source": {
-                                 "api": "attribute",
-                                 "path": "a:=(CFDE:subject_role_taxonomy:subject)/$M/(core_fact)/i:=(id_namespace)/r:=(a:role)/t:=(a:taxon)/$a/subject_id_namespace:=i:id,subject_local_id:=M:local_id,role_id:=r:id,taxonomy_id:=t:id"
+                                 "api": "entity",
+                                 "path": "(CFDE:subject_role_taxonomy:subject)/c2m2:subject_role_taxonomy"
                               },
                               "destination": {
                                  "name": "subject_role_taxonomy",
@@ -6376,8 +6376,8 @@
                            {
 
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(CFDE:subject_role_taxonomy:subject)/(role)/id,name,description"
+                                 "api": "entity",
+                                 "path": "(CFDE:subject_role_taxonomy:subject)/(role)=(c2m2:subject_role:nid)"
                               },
                               "destination": {
                                  "name": "subject_role",
@@ -6387,8 +6387,8 @@
                            {
 
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(CFDE:subject_role_taxonomy:subject)/(taxon)/id,name,description"
+                                 "api": "entity",
+                                 "path": "(CFDE:subject_role_taxonomy:subject)/(taxon)=(c2m2:ncbi_taxonomy:nid)"
                               },
                               "destination": {
                                  "name": "ncbi_taxonomy",
@@ -6397,8 +6397,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_sex/CFDE:sex/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_sex/(sex)=(c2m2:sex:nid)"
                               },
                               "destination": {
                                  "name": "sex",
@@ -6407,8 +6407,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_race/CFDE:race/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_race/(race)=(c2m2:race:nid)"
                               },
                               "destination": {
                                  "name": "race",
@@ -6417,8 +6417,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/CFDE:core_fact_ethnicity/CFDE:ethnicity/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_ethnicity/(ethnicity)=(c2m2:ethnicity:nid)"
                               },
                               "destination": {
                                  "name": "ethnicity",
@@ -6427,8 +6427,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:subject_race:subject)/v:=(race)/$a/subject_id_namespace:=i:id,subject_local_id:=M:local_id,race:=v:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_race/c2m2:subject_race"
                               },
                               "destination": {
                                  "name": "subject_race",
@@ -6437,8 +6437,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:subject_substance:subject)/v:=(substance)/$a/subject_id_namespace:=i:id,subject_local_id:=M:local_id,substance:=v:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_substance/c2m2:subject_substance"
                               },
                               "destination": {
                                  "name": "subject_substance",
@@ -6447,8 +6447,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:subject_disease:subject)/d:=(disease)/at:=(a:association_type)=(disease_association_type:nid)/$a/subject_id_namespace:=i:id,subject_local_id:=M:local_id,association_type:=at:id,disease:=d:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_disease/c2m2:subject_disease"
                               },
                               "destination": {
                                  "name": "subject_disease",
@@ -6457,8 +6457,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/i:=(id_namespace)/$M/a:=(CFDE:subject_phenotype:subject)/p:=(phenotype)/at:=(a:association_type)=(CFDE:phenotype_association_type:nid)/$a/subject_id_namespace:=i:id,subject_local_id:=M:local_id,association_type:=at:id,phenotype:=p:id"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_phenotype/c2m2:subject_phenotype"
                               },
                               "destination": {
                                  "name": "subject_phenotype",
@@ -6467,11 +6467,21 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "(core_fact)/(CFDE:core_fact_disease:core_fact)/(disease)/id,name,description"
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_disease/(disease)=(c2m2:disease:nid)"
                               },
                               "destination": {
                                  "name": "disease",
+                                 "type": "csv"
+                              }
+                           },
+                           {
+                              "source": {
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_phenotype/(phenotype)=(c2m2:phenotype:nid)"
+                              },
+                              "destination": {
+                                 "name": "phenotype",
                                  "type": "csv"
                               }
                            }
@@ -11913,438 +11923,6 @@
                   "projection_type": "acl",
                   "scope_acl": ["cfde_portal_members"]
                }
-            }
-         }
-      },
-
-      {
-         "profile": "tabular-data-resource",
-         "resourceSchema": "raw",
-         "name": "collection",
-         "description": "Raw (original) C2M2 submission collection data",
-         "schema": {
-            "fields": [
-               {
-                  "name": "nid",
-                  "title": "Numeric ID",
-                  "type": "integer",
-                  "constraints": {
-                     "required": true,
-                     "unique": true
-                  }
-               },
-               {
-                  "name": "id_namespace",
-                  "description": "A CFDE-cleared identifier representing the top-level data space containing this collection [part 1 of 2-component composite primary key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "local_id",
-                  "description": "An identifier representing this collection, unique within this id_namespace [part 2 of 2-component composite primary key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "persistent_id",
-                  "description": "A persistent, resolvable (not necessarily retrievable) URI or compact ID permanently attached to this collection",
-                  "type": "string"
-               },
-               {
-                  "name": "creation_time",
-                  "description": "An ISO 8601 -- RFC 3339 (subset)-compliant timestamp documenting this collection's creation time: YYYY-MM-DDTHH:MM:SS±NN:NN",
-                  "type": "datetime",
-                  "format": "any"
-               },
-               {
-                  "name": "abbreviation",
-                  "description": "A very short display label for this collection",
-                  "type": "string",
-                  "constraints": {
-                     "pattern": "^[a-zA-Z0-9_]+$"
-                  }
-               },
-               {
-                  "name": "name",
-                  "description": "A short, human-readable, machine-read-friendly label for this collection",
-                  "type": "string"
-               },
-               {
-                  "name": "description",
-                  "description": "A human-readable description of this collection",
-                  "type": "string"
-               }
-            ],
-            "missingValues": [ "" ],
-            "primaryKey": [ "nid" ],
-            "foreignKeys": [
-               {
-                  "fields": "nid",
-                  "constraint_name": "collection_nid_fkey",
-                  "reference": {
-                     "resourceSchema": "CFDE",
-                     "resource": "collection",
-                     "fields": "nid"
-                  }
-               }
-            ]
-         },
-         "deriva": {
-            "indexing_preferences": {
-               "btree": false,
-               "trgm": false
-            }
-         }
-      },
-      {
-         "profile": "tabular-data-resource",
-         "resourceSchema": "raw",
-         "name": "file",
-         "description": "Raw (original) c2m2 submission file data",
-         "schema": {
-            "fields": [
-               {
-                  "name": "nid",
-                  "title": "Numeric ID",
-                  "type": "integer",
-                  "constraints": {
-                     "required": true,
-                     "unique": true
-                  }
-               },
-               {
-                  "name": "id_namespace",
-                  "description": "A CFDE-cleared identifier representing the top-level data space containing this file [part 1 of 2-component composite primary key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "local_id",
-                  "description": "An identifier representing this file, unique within this id_namespace [part 2 of 2-component composite primary key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "project_id_namespace",
-                  "description": "The id_namespace of the primary project within which this file was created [part 1 of 2-component composite foreign key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "project_local_id",
-                  "description": "The local_id of the primary project within which this file was created [part 2 of 2-component composite foreign key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "persistent_id",
-                  "description": "A persistent, resolvable (not necessarily retrievable) URI or compact ID permanently attached to this file",
-                  "type": "string"
-               },
-               {
-                  "name": "creation_time",
-                  "description": "An ISO 8601 -- RFC 3339 (subset)-compliant timestamp documenting this file's creation time: YYYY-MM-DDTHH:MM:SS±NN:NN",
-                  "type": "datetime",
-                  "format": "any"
-               },
-               {
-                  "name": "size_in_bytes",
-                  "description": "The size of this file in bytes",
-                  "type": "integer"
-               },
-               {
-                  "name": "uncompressed_size_in_bytes",
-                  "description": "The total decompressed size in bytes of the contents of this file: null if this file is not compressed",
-                  "type": "integer"
-               },
-               {
-                  "name": "sha256",
-                  "description": "(preferred) SHA-256 checksum for this file [sha256, md5 cannot both be null]",
-                  "type": "string",
-                  "format": "binary"
-               },
-               {
-                  "name": "md5",
-                  "description": "(allowed) MD5 checksum for this file [sha256, md5 cannot both be null]",
-                  "type": "string",
-                  "format": "binary"
-               },
-               {
-                  "name": "filename",
-                  "description": "A filename with no prepended PATH information",
-                  "type": "string",
-                  "constraints": {
-                     "pattern": "^[^\/\\:]+$"
-                  }
-               },
-               {
-                  "name": "file_format",
-                  "description": "An EDAM CV term ID identifying the digital format of this file (e.g. TSV or FASTQ): if this file is compressed, this should be its _uncompressed_ format",
-                  "type": "string"
-               },
-               {
-                  "name": "compression_format",
-                  "description": "An EDAM CV term ID identifying the compression format of this file (e.g. gzip or bzip2): null if this file is not compressed",
-                  "type": "string"
-               },
-               {
-                  "name": "data_type",
-                  "description": "An EDAM CV term ID identifying the type of information stored in this file (e.g. RNA sequence reads): null if is_bundle is set to true",
-                  "type": "string"
-               },
-               {
-                  "name": "assay_type",
-                  "description": "An OBI CV term ID describing the type of experiment that generated the results summarized by this file",
-                  "type": "string"
-               },
-               {
-                  "name": "analysis_type",
-                  "description": "An OBI CV term ID describing the type of analytic operation that generated this file",
-                  "type": "string"
-               },
-               {
-                  "name": "mime_type",
-                  "description": "A MIME type describing this file",
-                  "type": "string"
-               },
-               {
-                  "name": "bundle_collection_id_namespace",
-                  "description": "If this file is a bundle encoding more than one sub-file, this field gives the id_namespace of a collection listing the bundle's sub-file contents. Null otherwise.",
-                  "type": "string"
-               },
-               {
-                  "name": "bundle_collection_local_id",
-                  "description": "If this file is a bundle encoding more than one sub-file, this field gives the local_id of a collection listing the bundle's sub-file contents. Null otherwise.",
-                  "type": "string"
-               }
-            ],
-            "missingValues": [ "" ],
-            "primaryKey": [ "nid" ],
-            "foreignKeys": [
-               {
-                  "fields": "nid",
-                  "constraint_name": "file_nid_fkey",
-                  "reference": {
-                     "resourceSchema": "CFDE",
-                     "resource": "file",
-                     "fields": "nid"
-                  }
-               }
-            ]
-         },
-         "deriva": {
-            "indexing_preferences": {
-               "btree": false,
-               "trgm": false
-            }
-         }
-      },
-      {
-         "profile": "tabular-data-resource",
-         "resourceSchema": "raw",
-         "name": "biosample",
-         "title": "biosample",
-         "description": "Raw (original) c2m2 submission biosample data",
-         "schema": {
-            "fields": [
-               {
-                  "name": "nid",
-                  "title": "Numeric ID",
-                  "type": "integer",
-                  "constraints": {
-                     "required": true,
-                     "unique": true
-                  }
-               },
-               {
-                  "name": "id_namespace",
-                  "description": "A CFDE-cleared identifier representing the top-level data space containing this biosample [part 1 of 2-component composite primary key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "local_id",
-                  "description": "An identifier representing this biosample, unique within this id_namespace [part 2 of 2-component composite primary key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "project_id_namespace",
-                  "description": "The id_namespace of the primary project within which this biosample was created [part 1 of 2-component composite foreign key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "project_local_id",
-                  "description": "The local_id of the primary project within which this biosample was created [part 2 of 2-component composite foreign key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "persistent_id",
-                  "description": "A persistent, resolvable (not necessarily retrievable) URI or compact ID permanently attached to this biosample",
-                  "type": "string"
-               },
-               {
-                  "name": "creation_time",
-                  "description": "An ISO 8601 -- RFC 3339 (subset)-compliant timestamp documenting this biosample's creation time: YYYY-MM-DDTHH:MM:SS±NN:NN",
-                  "type": "datetime",
-                  "format": "any"
-               },
-               {
-                  "name": "assay_type",
-                  "description": "An OBI CV term ID describing the type of experiment that generated this biosample",
-                  "type": "string"
-               },
-               {
-                  "name": "anatomy",
-                  "description": "An UBERON CV term ID used to locate the origin of this biosample within the physiology of its source or host organism",
-                  "type": "string"
-               }
-            ],
-            "missingValues": [ "" ],
-            "primaryKey": [ "nid" ],
-            "foreignKeys": [
-               {
-                  "fields": "nid",
-                  "constraint_name": "biosample_nid_fkey",
-                  "reference": {
-                     "resourceSchema": "CFDE",
-                     "resource": "biosample",
-                     "fields": "nid"
-                  }
-               }
-            ]
-         },
-         "deriva": {
-            "indexing_preferences": {
-               "btree": false,
-               "trgm": false
-            }
-         }
-      },
-      {
-         "profile": "tabular-data-resource",
-         "resourceSchema": "raw",
-         "name": "subject",
-         "title": "subject",
-         "description": "Raw (original) c2m2 submission subject data",
-         "schema": {
-            "fields": [
-               {
-                  "name": "nid",
-                  "title": "Numeric ID",
-                  "type": "integer",
-                  "constraints": {
-                     "required": true,
-                     "unique": true
-                  }
-               },
-               {
-                  "name": "id_namespace",
-                  "description": "A CFDE-cleared identifier representing the top-level data space containing this subject [part 1 of 2-component composite primary key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "local_id",
-                  "description": "An identifier representing this subject, unique within this id_namespace [part 2 of 2-component composite primary key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "project_id_namespace",
-                  "description": "The id_namespace of the primary project within which this subject was studied [part 1 of 2-component composite foreign key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "project_local_id",
-                  "description": "The local_id of the primary project within which this subject was studied [part 2 of 2-component composite foreign key]",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "persistent_id",
-                  "description": "A persistent, resolvable (not necessarily retrievable) URI or compact ID permanently attached to this subject",
-                  "type": "string"
-               },
-               {
-                  "name": "creation_time",
-                  "description": "An ISO 8601 -- RFC 3339 (subset)-compliant timestamp documenting this subject record's creation time: YYYY-MM-DDTHH:MM:SS±NN:NN",
-                  "type": "datetime",
-                  "format": "any"
-               },
-               {
-                  "name": "granularity",
-                  "description": "A CFDE CV term categorizing this subject by multiplicity",
-                  "type": "string",
-                  "constraints": {
-                     "required": true
-                  }
-               },
-               {
-                  "name": "sex",
-                  "description": "The sex of this subject",
-                  "type": "string"
-               },
-               {
-                  "name": "ethnicity",
-                  "description": "The ethnicity of this subject",
-                  "type": "string"
-               },
-               {
-                  "name": "age_at_enrollment",
-                  "description": "The age in years (with a fixed precision of two digits past the decimal point) of this subject when they were first enrolled in the primary project within which they were studied",
-                  "type": "number"
-               }
-            ],
-            "missingValues": [ "" ],
-            "primaryKey": [ "nid" ],
-            "foreignKeys": [
-               {
-                  "fields": "nid",
-                  "constraint_name": "subject_nid_fkey",
-                  "reference": {
-                     "resourceSchema": "CFDE",
-                     "resource": "subject",
-                     "fields": "nid"
-                  }
-               }
-            ]
-         },
-         "deriva": {
-            "indexing_preferences": {
-               "btree": false,
-               "trgm": false
             }
          }
       }

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -3735,8 +3735,8 @@
                         "outputs": [
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "cf:=(core_fact)/i:=(id_namespace)/$M/id_namespace:=i:id,local_id,persistent_id,creation_time,abbreviation,name,description"
+                                 "api": "entity",
+                                 "path": "(nid)=(raw:collection:nid)"
                               },
                               "destination": {
                                  "name": "collection",
@@ -3785,8 +3785,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_in_collection/f:=(file)/cf:=(core_fact)/i1:=(id_namespace)/p:=(cf:project)/i2:=(id_namespace)/ff:=left(cf:file_format)=(CFDE:file_format:nid)/fcf:=left(cf:compression_format)=(CFDE:file_format:nid)/dt:=left(cf:data_type)=(CFDE:data_type:nid)/at:=left(cf:assay_type)=(CFDE:assay_type:nid)/mt:=left(cf:mime_type)=(CFDE:mime_type:nid)/bc:=left(f:bundle_collection)=(CFDE:collection:nid)/left(core_fact)=(CFDE:core_fact:nid)/i3:=left(id_namespace)=(CFDE:id_namespace:nid)/ant:=left(cf:analysis_type)=(CFDE:analysis_type:nid)/$f/id_namespace:=i1:id,local_id,project_id_namespace:=i2:id,project_local_id:=p:local_id,persistent_id,creation_time,size_in_bytes,uncompressed_size_in_bytes,sha256,md5,filename,file_format:=ff:id,compression_format:=fcf:id,data_type:=dt:id,assay_type:=at:id,analysis_type:=ant:id,mime_type:=mt:id,bundle_collection_id_namespace:=i3:id,bundle_collection_local_id:=bc:local_id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_in_collection/(file)/(nid)=(raw:file:nid)"
                               },
                               "destination": {
                                  "name": "file",
@@ -3825,8 +3825,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_in_collection/b:=(biosample)/cf:=(core_fact)/i1:=(id_namespace)/p:=(cf:project)/i2:=(id_namespace)/an:=left(cf:anatomy)=(CFDE:anatomy:nid)/at:=left(cf:assay_type)=(CFDE:assay_type:nid)/$b/id_namespace:=i1:id,local_id,project_id_namespace:=i2:id,project_local_id:=p:local_id,persistent_id,creation_time,anatomy:=an:id,assay_type:=at:id"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_in_collection/(biosample)/(nid)=(raw:biosample:nid)"
                               },
                               "destination": {
                                  "name": "biosample",
@@ -3935,8 +3935,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:subject_in_collection/s:=(subject)/cf:=(core_fact)/i1:=(id_namespace)/p:=(cf:project)/i2:=(id_namespace)/sg:=(cf:subject_granularity)/sx:=left(cf:sex)=(CFDE:sex:nid)/eth:=left(cf:ethnicity)=(CFDE:ethnicity:nid)/$s/id_namespace:=i1:id,local_id,project_id_namespace:=i2:id,project_local_id:=p:local_id,persistent_id,creation_time,granularity:=sg:id,sex:=sx:id,ethnicity:=eth:id,age_at_enrollment"
+                                 "api": "entity",
+                                 "path": "CFDE:subject_in_collection/(subject)/(nid)=(raw:subject:nid)"
                               },
                               "destination": {
                                  "name": "subject",
@@ -4632,8 +4632,8 @@
                         "outputs": [
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "cf:=(core_fact)/i:=(cf:id_namespace)/p:=(cf:project)/pi:=(p:id_namespace)/ff:=left(cf:file_format)=(CFDE:file_format:nid)/fcf:=left(cf:compression_format)=(CFDE:file_format:nid)/dt:=left(cf:data_type)=(CFDE:data_type:nid)/at:=left(cf:assay_type)=(CFDE:assay_type:nid)/mt:=left(cf:mime_type)=(CFDE:mime_type:nid)/bc:=left(M:bundle_collection)=(CFDE:collection:nid)/left(core_fact)=(CFDE:core_fact:nid)/i3:=left(id_namespace)=(CFDE:id_namespace:nid)/ant:=left(cf:analysis_type)=(CFDE:analysis_type:nid)/$M/id_namespace:=i:id,local_id,project_id_namespace:=pi:id,project_local_id:=p:local_id,persistent_id,creation_time,size_in_bytes,uncompressed_size_in_bytes,sha256,md5,filename,file_format:=ff:id,compression_format:=fcf:id,data_type:=dt:id,assay_type:=at:id,analysis_type:=ant:id,mime_type:=mt:id,bundle_collection_id_namespace:=i3:id,bundle_collection_local_id:=bc:local_id"
+                                 "api": "entity",
+                                 "path": "(nid)=(raw:file:nid)"
                               },
                               "destination": {
                                  "name": "file",
@@ -4692,8 +4692,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_biosample/b:=(biosample)/cf:=(core_fact)/i1:=(id_namespace)/p:=(cf:project)/i2:=(id_namespace)/a:=left(cf:anatomy)=(CFDE:anatomy:nid)/at:=left(cf:assay_type)=(CFDE:assay_type:nid)/$b/id_namespace:=i1:id,local_id,project_id_namespace:=i2:id,project_local_id:=p:local_id,persistent_id,creation_time,anatomy:=a:id,assay_type:=at:id"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_biosample/(biosample)/(nid)=(raw:biosample:nid)"
                               },
                               "destination": {
                                  "name": "biosample",
@@ -4792,8 +4792,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:file_describes_subject/s:=(subject)/cf:=(core_fact)/i1:=(id_namespace)/p:=(cf:project)/i2:=(id_namespace)/sg:=(cf:subject_granularity)/sx:=left(cf:sex)=(CFDE:sex:nid)/eth:=left(cf:ethnicity)=(CFDE:ethnicity:nid)/$s/id_namespace:=i1:id,local_id,project_id_namespace:=i2:id,project_local_id:=p:local_id,persistent_id,creation_time,granularity:=sg:id,sex:=sx:id,ethnicity:=eth:id,age_at_enrollment"
+                                 "api": "entity",
+                                 "path": "CFDE:file_describes_subject/(subject)/(nid)=(raw:subject:nid)"
                               },
                               "destination": {
                                  "name": "subject",
@@ -5537,8 +5537,8 @@
                         "outputs": [
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "cf:=(core_fact)/i1:=(id_namespace)/p:=(cf:project)/i2:=(id_namespace)/an:=left(cf:anatomy)=(CFDE:anatomy:nid)/at:=left(cf:assay_type)=(CFDE:assay_type:nid)/$M/id_namespace:=i1:id,local_id,project_id_namespace:=i2:id,project_local_id:=p:local_id,persistent_id,creation_time,anatomy:=an:id,assay_type:=at:id"
+                                 "api": "entity",
+                                 "path": "(nid)=(raw:biosample:nid)"
                               },
                               "destination": {
                                  "name": "biosample",
@@ -5667,8 +5667,8 @@
                            },
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "CFDE:biosample_from_subject/s:=(subject)/cf:=(core_fact)/i1:=(id_namespace)/p:=(cf:project)/i2:=(p:id_namespace)/sg:=(cf:subject_granularity)/sx:=left(cf:sex)=(CFDE:sex:nid)/eth:=left(cf:ethnicity)=(CFDE:ethnicity:nid)/$s/id_namespace:=i1:id,local_id,project_id_namespace:=i2:id,project_local_id:=p:local_id,persistent_id,creation_time,granularity:=sg:id,sex:=sx:id,ethnicity:=eth:id,age_at_enrollment"
+                                 "api": "entity",
+                                 "path": "CFDE:biosample_from_subject/(subject)/(nid)=(raw:subject:nid)"
                               },
                               "destination": {
                                  "name": "subject",
@@ -6324,8 +6324,8 @@
                         "outputs": [
                            {
                               "source": {
-                                 "api": "attribute",
-                                 "path": "cf:=(core_fact)/i1:=(id_namespace)/p:=(cf:project)/i2:=(id_namespace)/sg:=(cf:subject_granularity)/sx:=left(cf:sex)=(CFDE:sex:nid)/eth:=left(cf:ethnicity)=(CFDE:ethnicity:nid)/$M/id_namespace:=i1:id,local_id,project_id_namespace:=i2:id,project_local_id:=p:local_id,persistent_id,creation_time,granularity:=sg:id,sex:=sx:id,ethnicity:=eth:id,age_at_enrollment"
+                                 "api": "entity",
+                                 "path": "(nid)=(raw:subject:nid)"
                               },
                               "destination": {
                                  "name": "subject",

--- a/cfde_deriva/datapackage.py
+++ b/cfde_deriva/datapackage.py
@@ -102,21 +102,33 @@ def make_session_config():
     })
     return session_config
 
-def tnames_topo_sorted(tables):
-    """Return table names from model topologically sorted to put dependant after references tables.
+def tables_topo_sorted(tables):
+    """Return tables topologically sorted to put dependant after references tables.
 
-    :param tables: dict-like map of table instances
+    :param tables: iterable of table instances
     """
+    def tname(table):
+        return (
+            table.schema.name,
+            table.name
+        )
     def target_tname(fkey):
-        return fkey.referenced_columns[0].table.name
-    return topo_sorted({
-        table.name: [
-            target_tname(fkey)
-            for fkey in table.foreign_keys
-            if target_tname(fkey) != table.name and target_tname(fkey) in tables
-        ]
-        for table in tables.values()
-    })
+        return (
+            fkey.referenced_columns[0].table.schema.name,
+            fkey.referenced_columns[0].table.name
+        )
+    name_map = { tname(table): table for table in tables }
+    return [
+        name_map[tname_pair]
+        for tname_pair in topo_sorted({
+                tname(table): [
+                    target_tname(fkey)
+                    for fkey in table.foreign_keys
+                    if target_tname(fkey) != tname(table) and target_tname(fkey) in name_map
+                ]
+                for table in tables
+        })
+    ]
 
 class CfdeDataPackage (object):
     # the translation stores frictionless table resource metadata under this annotation
@@ -164,7 +176,7 @@ class CfdeDataPackage (object):
         self.doc_model_root = Model(None, self.model_doc)
         self.doc_cfde_schema = self.doc_model_root.schemas.get('CFDE')
 
-        if not set(self.model_doc['schemas']).issubset({'CFDE', 'public'}):
+        if not set(self.model_doc['schemas']).issubset({'CFDE', 'public', 'raw'}):
             raise ValueError('Unexpected schema set in data package: %s' % (set(self.model_doc['schemas']),))
 
     def set_catalog(self, catalog, registry=None):
@@ -633,14 +645,6 @@ class CfdeDataPackage (object):
 
         return row2dict
 
-    def data_tnames_topo_sorted(self, source_schema=None):
-        tables_doc = self.model_doc['schemas']['CFDE']['tables']
-        return tnames_topo_sorted({
-            tname: table
-            for tname, table in source_schema.tables.items()
-            if tname in tables_doc
-        })
-
     def dump_data_files(self, resources=None, dump_dir=None):
         """Dump resources to TSV files (inverse of normal load process)
 
@@ -720,11 +724,10 @@ class CfdeDataPackage (object):
         :param onconflict: ERMrest onconflict query parameter to emulate (default abort)
         """
         tables_doc = self.model_doc['schemas']['CFDE']['tables']
-        for tname in self.data_tnames_topo_sorted(source_schema=self.doc_cfde_schema):
+        for table in tables_topo_sorted(self.doc_cfde_schema.tables.values()):
             # we are doing a clean load of data in fkey dependency order
-            table = self.doc_cfde_schema.tables[tname]
-            resource = tables_doc[tname]["annotations"].get(self.resource_tag, {})
-            logger.debug('Loading table "%s"...' % tname)
+            resource = tables_doc[table.name]["annotations"].get(self.resource_tag, {})
+            logger.debug('Loading table "%s"...' % table.name)
             if "path" not in resource:
                 continue
             def open_package():
@@ -841,16 +844,15 @@ class CfdeDataPackage (object):
         if progress is None:
             progress = dict()
         tables_doc = self.model_doc['schemas']['CFDE']['tables']
-        for tname in self.data_tnames_topo_sorted(source_schema=self.doc_cfde_schema):
+        for table in tables_topo_sorted(self.doc_cfde_schema.tables.values()):
             # we are doing a clean load of data in fkey dependency order
-            table = self.doc_cfde_schema.tables[tname]
-            resource = tables_doc[tname]["annotations"].get(self.resource_tag, {})
+            resource = tables_doc[table.name]["annotations"].get(self.resource_tag, {})
             if "path" not in resource:
                 continue
-            if progress.get(tname):
-                logger.info("Skipping sqlite import for %s due to existing progress marker" % tname)
+            if progress.get(table.name):
+                logger.info("Skipping sqlite import for %s due to existing progress marker" % table.name)
                 continue
-            logger.debug('Importing table "%s" into sqlite...' % tname)
+            logger.debug('Importing table "%s" into sqlite...' % table.name)
             def open_package():
                 if isinstance(self.package_filename, _PackageDataName):
                     return self.package_filename.get_data_stringio(resource["path"])
@@ -923,7 +925,7 @@ class CfdeDataPackage (object):
                             logger.error("Table %s data load FAILED from "
                                          "%s: %s" % (table.name, self.package_filename, e))
                             raise
-                    progress[tname] = True
+                    progress[table.name] = True
                     logger.info("All data for table %s loaded from %s." % (table.name, self.package_filename))
             except UnicodeDecodeError as e:
                 if table_error_callback:
@@ -956,26 +958,25 @@ class CfdeDataPackage (object):
         cur = None
         try:
             cur = conn.cursor()
-            for tname in self.data_tnames_topo_sorted(source_schema=self.doc_cfde_schema):
-                if tname not in tablenames:
+            for table in tables_topo_sorted(self.doc_cfde_schema.tables.values()):
+                if table.name not in tablenames:
                     continue
 
-                table = self.doc_cfde_schema.tables[tname]
-                sql_checks = self.doc_cfde_schema.tables[tname].annotations.get(self.resource_tag, {}).get('check_sql_paths', [])
+                sql_checks = table.annotations.get(self.resource_tag, {}).get('check_sql_paths', [])
                 skip_checks = json.loads(os.getenv('CFDE_SKIP_SQL_CHECKS', '{}'))
-                resource = tables_doc[tname]["annotations"].get(self.resource_tag, {})
+                resource = tables_doc[table.name]["annotations"].get(self.resource_tag, {})
 
-                progress.setdefault(tname, {})
+                progress.setdefault(table.name, {})
 
                 for path in sql_checks:
                     if skip_checks is True or skip_checks.get(path[0:-4]):
-                        logger.info('Skipping custom SQL check %r for table %r due to CFDE_SKIP_SQL_CHECKS env. var.' % (path, tname))
+                        logger.info('Skipping custom SQL check %r for table %r due to CFDE_SKIP_SQL_CHECKS env. var.' % (path, table.name))
                         continue
-                    progress[tname].setdefault(path, None)
-                    if progress[tname][path] is not None:
-                        logger.info('Skipping custom SQL check %r for table %r due to progress marker' % (path, tname))
+                    progress[table.name].setdefault(path, None)
+                    if progress[table.name][path] is not None:
+                        logger.info('Skipping custom SQL check %r for table %r due to progress marker' % (path, table.name))
                         continue
-                    logger.info('Running custom SQL check %r for table %r' % (path, tname,))
+                    logger.info('Running custom SQL check %r for table %r' % (path, table.name,))
                     sql = self.package_filename.get_data_str(path)
                     cur.execute(sql)
                     row = cur.fetchone()
@@ -987,25 +988,25 @@ class CfdeDataPackage (object):
                             example_data,
                             (' (and %s others...)' % (count - 1)) if count > 1 else '',
                         )
-                        errors_by_tname.setdefault(tname, []).append(mesg)
+                        errors_by_tname.setdefault(table.name, []).append(mesg)
                         if first_error_mesg is None:
-                            first_error_mesg = 'Table %s %s' % (tname, mesg)
-                        logger.error('custom SQL check %r for table %r ERROR: %s' % (path, tname, mesg))
-                        progress[tname][path] = False
+                            first_error_mesg = 'Table %s %s' % (table.name, mesg)
+                        logger.error('custom SQL check %r for table %r ERROR: %s' % (path, table.name, mesg))
+                        progress[table.name][path] = False
                     else:
-                        logger.info('custom SQL check %r for table %r OK' % (path, tname))
-                        progress[tname][path] = True
+                        logger.info('custom SQL check %r for table %r OK' % (path, table.name))
+                        progress[table.name][path] = True
 
                 if table.foreign_keys:
-                    logger.info('Checking foreign keys for table %r' % (tname,))
+                    logger.info('Checking foreign keys for table %r' % (table.name,))
                 for fkey in table.foreign_keys:
                     if fkey.pk_table.schema.name != table.schema.name:
                         # only consider single schema in this sqite db
-                        progress[tname][fkey.constraint_name] = 'skip'
+                        progress[table.name][fkey.constraint_name] = 'skip'
                         logger.info("Skipping foreign key %r which references outside schema %r" % (fkey.constraint_name, table.schema.name))
                         continue
-                    progress[tname].setdefault(fkey.constraint_name, None)
-                    if progress[tname][fkey.constraint_name] is not None:
+                    progress[table.name].setdefault(fkey.constraint_name, None)
+                    if progress[table.name][fkey.constraint_name] is not None:
                         logger.info("Skipping foreign key %r due to progress marker" % (fkey.constraint_name,))
                         continue
                     col_map = list(fkey.column_map.items())
@@ -1052,18 +1053,18 @@ LIMIT 1;
                             (' (and %s others...)' % (row[0] - 1)) if row[0] > 1 else '',
                             fkey.pk_table.name,
                         )
-                        errors_by_tname.setdefault(tname, []).append(mesg)
+                        errors_by_tname.setdefault(table.name, []).append(mesg)
                         if first_error_mesg is None:
-                            first_error_mesg = 'Table %s %s' % (tname, mesg)
+                            first_error_mesg = 'Table %s %s' % (table.name, mesg)
                         logger.error('foreign key %r ERROR: %s' % (fkey.constraint_name, mesg))
-                        progress[tname][fkey.constraint_name] = False
+                        progress[table.name][fkey.constraint_name] = False
                     else:
                         logger.info("foreign key %r OK" % (fkey.constraint_name,))
-                        progress[tname][fkey.constraint_name] = True
+                        progress[table.name][fkey.constraint_name] = True
 
-                if tname in errors_by_tname:
+                if table.name in errors_by_tname:
                     if table_error_callback:
-                        table_error_callback(tname, resource.get('path'), '; '.join(errors_by_tname[tname]))
+                        table_error_callback(table.name, resource.get('path'), '; '.join(errors_by_tname[table.name]))
 
             if errors_by_tname:
                 raise InvalidDatapackage('Errors found in %s tables %r. First error: %s' % (len(errors_by_tname), list(errors_by_tname), first_error_mesg))
@@ -1071,14 +1072,14 @@ LIMIT 1;
             if cur is not None:
                 cur.close()
 
-    def load_sqlite_tables(self, conn, onconflict='abort', table_done_callback=None, table_error_callback=None, tablenames=None, progress=None, table_queries={}, skip_cols={'RID', 'RCT', 'RMT', 'RCB', 'RMB'}):
+    def load_sqlite_tables(self, conn, onconflict='abort', tables=None, table_done_callback=None, table_error_callback=None, progress=None, table_queries={}, skip_cols={'RID', 'RCT', 'RMT', 'RCB', 'RMB'}):
         """Load tabular data from sqlite table into corresponding catalog table.
 
         :param conn: Existing sqlite3 connection to use as data source.
         :param onconflict: ERMrest onconflict query parameter for entity POST (default 'abort')
+        :param tables: Iterable of table instances from self.doc_model_root (default None means self.doc_cfde_schema.tables.values())
         :param table_done_callback: Optional callback to signal completion of one table, lambda tname, tpath: ...
         :param table_error_callback: Optional callback to signal error for one table, lambda tname, tpath, msg: ...
-        :param tablenames: Optional set of tablenames to load (default None means load all tables)
         :param progress: Optional, mutable progress/restart-marker dictionary
         :param table_queries: Optional, override source SQL query for specific table names
         :param skip_cols: Optiona, override set of column names to ignore (default ERMrest system columns)
@@ -1087,27 +1088,27 @@ LIMIT 1;
             progress = dict()
         if not self.package_filename in {portal_schema_json, registry_schema_json}:
             raise ValueError('load_sqlite_tables() is only valid for built-in portal datapackages')
-        tables_doc = self.model_doc['schemas']['CFDE']['tables']
-        if tablenames is None:
-            tablenames = set(tables_doc.keys())
+        if tables is None:
+            tables = self.doc_cfde_schema.tables.values()
         cur = conn.cursor()
-        for tname in self.data_tnames_topo_sorted(source_schema=self.doc_cfde_schema):
-            # we are copying sqlite table content to catalog under same table name
-            table = self.doc_cfde_schema.tables[tname]
-            resource = tables_doc[tname]["annotations"].get(self.resource_tag, {})
-
-            if tname not in tablenames:
-                # skip tables excluded in caller-supplied tablenames list
-                continue
-
-            cur.execute("SELECT true FROM sqlite_master WHERE type = 'table' AND name = %s" % (sql_literal(tname),))
+        for table in tables_topo_sorted(tables):
+            # we are loading a catalog table from a sqlite table with the same table name
+            cur.execute("SELECT true FROM sqlite_master WHERE type = 'table' AND name = %s" % (sql_literal(table.name),))
             found = cur.fetchone()
             if found is None:
                 # skip tables that don't exist in sqlite
                 continue
 
-            logger.debug('Loading table "%s" from sqlite to catalog...' % tname)
-            entity_url = "/entity/CFDE:%s?onconflict=%s" % (
+            resource = self.model_doc["schemas"] \
+                           .get(table.schema.name, {}) \
+                           .get("tables", {}) \
+                           .get(table.name, {}) \
+                           .get("annotations", {}) \
+                           .get(self.resource_tag, {})
+
+            logger.debug('Loading table %r.%r from sqlite to catalog...' % (table.schema.name, table.name))
+            entity_url = "/entity/%s:%s?onconflict=%s" % (
+                urlquote(table.schema.name),
                 urlquote(table.name),
                 {
                     'abort': 'abort',
@@ -1119,7 +1120,8 @@ LIMIT 1;
             cols = [ col for col in table.columns if col.name not in skip_cols ]
             colnames = [ col.name for col in cols ]
             # HACK: this ONLY works for our vocab-like tables keyed by 'id'
-            update_url = "/attributegroup/CFDE:%s/id;%s" % (
+            update_url = "/attributegroup/%s:%s/id;%s" % (
+                urlquote(table.schema.name),
                 urlquote(table.name),
                 ",".join([ cname for cname in colnames if cname != 'id']),
             )
@@ -1128,7 +1130,7 @@ LIMIT 1;
                 (lambda x: json.loads(x) if x is not None else x) if col.type.typename in ('text[]', 'json', 'jsonb') else lambda x: x
                 for col in cols
             ]
-            position = progress.get(tname, None)
+            position = progress.get(table.name, None)
 
             if position is not None:
                 logger.info("Restarting after %r due to existing restart marker" % (position,))
@@ -1189,7 +1191,8 @@ LIMIT 1;
                     def get_existing_batch():
                         nonlocal eposition
                         r = self.catalog.get(
-                            "/attribute/CFDE:%s/%s@sort(id)%s?limit=%d" % (
+                            "/attribute/%s:%s/%s@sort(id)%s?limit=%d" % (
+                                urlquote(table.schema.name),
                                 urlquote(table.name),
                                 ",".join([ urlquote(cname) for cname in colnames ]),
                                 ("@after(%s)" % urlquote(eposition)) if eposition is not None else "",
@@ -1245,7 +1248,7 @@ LIMIT 1;
                             r = self.catalog.put(update_url, json=batch).json()
                             logger.debug("PUT /attributegroup/ sent for %d existing rows" % len(batch))
 
-                    progress[tname] = marker
+                    progress[table.name] = marker
                     nrows += blen
                     logger.info("Batch of %d rows loaded for %s (%d cumulative)" % (blen, table.name, nrows))
 
@@ -1573,8 +1576,8 @@ FROM %(srcschema)s.%(tname)s src
             resource['name']: resource
             for resource in self.package_def['resources']
         }
-        for tname in self.data_tnames_topo_sorted(source_schema=self.doc_cfde_schema):
-            resource = tables_map[tname]
+        for table in tables_topo_sorted(self.doc_cfde_schema.tables.values()):
+            resource = tables_map[table.name]
             for column in resource['schema']['fields']:
                 if 'derivation_sql_path' in column and do_etl_columns:
                     if progress.setdefault("columns", {}).setdefault(resource["name"], {}).get(column["name"], False):
@@ -1600,8 +1603,8 @@ FROM %(srcschema)s.%(tname)s src
 
         Caller should manage transactions if desired.
         """
-        for tname in self.data_tnames_topo_sorted(source_schema=self.doc_cfde_schema):
-            for sql in self.table_sqlite_ddl(self.doc_cfde_schema.tables[tname]):
+        for table in tables_topo_sorted(self.doc_cfde_schema.tables.values()):
+            for sql in self.table_sqlite_ddl(self.doc_cfde_schema.tables[table.name]):
                 conn.execute(sql)
 
     def table_sqlite_ddl(self, table):

--- a/cfde_deriva/release.py
+++ b/cfde_deriva/release.py
@@ -566,6 +566,7 @@ class Release (object):
             logger.info('Uploading all release content...')
             self.dump_progress(progress)
             Submission.upload_sqlite_content(catalog, self.portal_prep_sqlite_filename, progress=progress.setdefault('upload', {}))
+            Submission.upload_sqlite_raw_content(catalog, self.ingest_sqlite_filename, progress=progress.setdefault('upload_raw', {}))
             logger.info('All release content successfully uploaded to %(ermrest_url)s' % rel)
             browse_url = '/chaise/recordset/#%s/CFDE:file' % catalog.catalog_id
             summary_url = '/pdashboard.html?catalogId=%s' % catalog.catalog_id

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -1079,7 +1079,7 @@ LEFT OUTER JOIN project_root pr ON (d.project = pr.project);
             logger.debug('Idempotently uploading raw data from %s' % (sqlite_filename,))
             canon_dp = CfdeDataPackage(portal_schema_json)
             canon_dp.set_catalog(catalog)
-            tables = canon_dp.doc_model_root.schemas['raw'].tables.values()
+            tables = canon_dp.doc_model_root.schemas['c2m2'].tables.values()
             canon_dp.load_sqlite_tables(conn, onconflict='skip', tables=tables, table_done_callback=table_done_callback, table_error_callback=table_error_callback, progress=progress)
 
     @classmethod
@@ -1302,7 +1302,7 @@ WHERE id IS NOT NULL
                 if 'CFDE' in review_model.schemas:
                     logger.info('Purging CFDE schema content on existing catalog %s...' % ermrest_url)
                     tables = list(review_model.schemas['CFDE'].tables.values())
-                    tables.extend(review_model.schemas['raw'].tables.values())
+                    tables.extend(review_model.schemas['c2m2'].tables.values())
                     for table in reversed(tables_topo_sorted(tables)):
                         submission.review_catalog.delete('/schema/%s/table/%s' % (
                             urlquote(table.schema.name),

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -22,11 +22,11 @@ from bdbag import bdbag_api
 from bdbag.bdbagit import BagError, BagValidationError
 import frictionless
 
-from deriva.core import DerivaServer, get_credential, init_logging, urlquote, topo_sorted
+from deriva.core import DerivaServer, get_credential, init_logging, urlquote
 
 from . import exception, tableschema
 from .registry import Registry, WebauthnUser, WebauthnAttribute, nochange, terms
-from .datapackage import CfdeDataPackage, submission_schema_json, portal_prep_schema_json, portal_schema_json, registry_schema_json, sql_literal, sql_identifier, make_session_config, tnames_topo_sorted
+from .datapackage import CfdeDataPackage, submission_schema_json, portal_prep_schema_json, portal_schema_json, registry_schema_json, sql_literal, sql_identifier, make_session_config, tables_topo_sorted
 from .cfde_login import get_archive_headers_map
 
 
@@ -1170,22 +1170,25 @@ WHERE v.id = t.id;
             registry_dp.load_sqlite_tables(
                 conn,
                 onconflict='update',
-                tablenames={
-                    'anatomy',
-                    'assay_type',
-                    'data_type',
-                    'disease',
-                    'file_format',
-                    'mime_type',
-                    'ncbi_taxonomy',
-                    'compound',
-                    'substance',
-                    'gene',
-                    'analysis_type',
-                    'phenotype',
-                    # don't need to update subject_role/subject_granularity/sex/race/ethnicity/assoc types
-                    # which are closed enums for the DCCs...
-                },
+                tables=[
+                    registry_dp.doc_cfde_schema.tables[tname]
+                    for tname in [
+                            'anatomy',
+                            'assay_type',
+                            'data_type',
+                            'disease',
+                            'file_format',
+                            'mime_type',
+                            'ncbi_taxonomy',
+                            'compound',
+                            'substance',
+                            'gene',
+                            'analysis_type',
+                            'phenotype',
+                            # don't need to update subject_role/subject_granularity/sex/race/ethnicity/assoc types
+                            # which are closed enums for the DCCs...
+                    ]
+                ],
                 # HACK: custom ETL we need to undo portal_prep normalization when copying to registry in native C2M2 form
                 table_queries={
                     'substance': '(SELECT s.nid, s.id, s.name, s.description, s.synonyms, c.id AS compound FROM substance s JOIN compound c ON (s.compound = c.nid))',

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -434,6 +434,7 @@ class Submission (object):
 
             next_error_state = terms.cfde_registry_dp_status.ops_error
             self.upload_sqlite_content(self.review_catalog, self.portal_prep_sqlite_filename, table_done_callback=dpt_update2, table_error_callback=dpt_error2)
+            self.upload_sqlite_raw_content(self.review_catalog, self.ingest_sqlite_filename, table_done_callback=dpt_update2, table_error_callback=dpt_error2)
 
             review_browse_url = '%s/chaise/recordset/#%s/CFDE:file' % (
                 self.review_catalog._base_server_uri,
@@ -1070,6 +1071,18 @@ LEFT OUTER JOIN project_root pr ON (d.project = pr.project);
             canon_dp.load_sqlite_tables(conn, onconflict='skip', table_done_callback=table_done_callback, table_error_callback=table_error_callback, progress=progress)
 
     @classmethod
+    def upload_sqlite_raw_content(cls, catalog, sqlite_filename, table_done_callback=None, table_error_callback=None, progress=None):
+        """Idempotently upload orignal datapackage content in sqlite db into review catalog."""
+        if progress is None:
+            progress = dict()
+        with sqlite3.connect(sqlite_filename) as conn:
+            logger.debug('Idempotently uploading raw data from %s' % (sqlite_filename,))
+            canon_dp = CfdeDataPackage(portal_schema_json)
+            canon_dp.set_catalog(catalog)
+            tables = canon_dp.doc_model_root.schemas['raw'].tables.values()
+            canon_dp.load_sqlite_tables(conn, onconflict='skip', tables=tables, table_done_callback=table_done_callback, table_error_callback=table_error_callback, progress=progress)
+
+    @classmethod
     def download_resource_markdown_to_sqlite(cls, registry, portal_prep_filename):
         """Retrieve resource_markdown content from registry into corresponding sqlite term records.
 
@@ -1288,10 +1301,15 @@ WHERE id IS NOT NULL
                 review_model = submission.review_catalog.getCatalogModel()
                 if 'CFDE' in review_model.schemas:
                     logger.info('Purging CFDE schema content on existing catalog %s...' % ermrest_url)
-                    for tname in reversed(tnames_topo_sorted(review_model.schemas['CFDE'].tables)):
-                        submission.review_catalog.delete('/schema/CFDE/table/%s' % urlquote(tname))
-                    logger.info('Reprovisioning CFDE schema content on existing catalog %s...' % ermrest_url)
-                    Submission.configure_review_catalog(registry, submission.review_catalog, id, provision=True)
+                    tables = list(review_model.schemas['CFDE'].tables.values())
+                    tables.extend(review_model.schemas['raw'].tables.values())
+                    for table in reversed(tables_topo_sorted(tables)):
+                        submission.review_catalog.delete('/schema/%s/table/%s' % (
+                            urlquote(table.schema.name),
+                            urlquote(table.name),
+                        ))
+                logger.info('Reprovisioning CFDE schema content on existing catalog %s...' % ermrest_url)
+                Submission.configure_review_catalog(registry, submission.review_catalog, id, provision=True)
         #
         submission.ingest()
 

--- a/cfde_deriva/tableschema.py
+++ b/cfde_deriva/tableschema.py
@@ -142,6 +142,7 @@ class CatalogConfigurator (object):
     }
     schema_acls = {
         "CFDE": { "select": [ authn_id.cfde_portal_admin ] },
+        "raw": { "select": [ authn_id.cfde_portal_admin ] },
         "public": { "select": [] },
     }
     schema_table_acls = {}
@@ -443,6 +444,7 @@ class ReleaseConfigurator (CatalogConfigurator):
         CatalogConfigurator.schema_acls,
         {
             "CFDE": { "select": ["*"] },
+            "raw": { "select": ["*"] },
         }
     )
 
@@ -472,6 +474,7 @@ class ReviewConfigurator (CatalogConfigurator):
             CatalogConfigurator.schema_acls,
             {
                 "CFDE": { "select": list(cfde_portal_viewers) },
+                "raw": { "select": list(cfde_portal_viewers) },
             }
         )
         if self.registry is not None and self.submission_id is not None:

--- a/cfde_deriva/tableschema.py
+++ b/cfde_deriva/tableschema.py
@@ -3,15 +3,19 @@
 """Translate basic Frictionless Table-Schema table definitions to Deriva."""
 
 import os
+import io
 import sys
 import json
 import hashlib
 import base64
 import logging
 import requests
+import pkgutil
 
 from deriva.core import tag, AttrDict, init_logging
 from deriva.core.ermrest_model import builtin_types, Model, Table, Column, Key, ForeignKey
+
+from .configs import submission, portal_prep, portal, registry
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +92,116 @@ terms = _attrdict_from_strings(
     'cfde_registry_rel_status:ops-error',
 )
 
+# some special singleton strings...
+class PackageDataName (object):
+    def __init__(self, package, filename):
+        self.package = package
+        self.filename = filename
+
+    def __str__(self):
+        return self.filename
+
+    def get_data(self, key=None):
+        """Get named content as raw buffer
+
+        :param key: Alternate name to lookup in package instead of self
+        """
+        if key is None:
+            key = self.filename
+        return pkgutil.get_data(self.package.__name__, key)
+
+    def get_data_str(self, key=None):
+        """Get named content as unicode decoded str
+
+        :param key: Alternate name to lookup in package instead of self
+        """
+        return self.get_data(key).decode()
+
+    def get_data_stringio(self, key=None):
+        """Get named content as unicode decoded StringIO buffer object
+
+        :param key: Alternate name to lookup in package instead of self
+        """
+        return io.StringIO(self.get_data_str(key))
+
+submission_schema_json = PackageDataName(submission, 'c2m2-datapackage.json')
+portal_prep_schema_json = PackageDataName(portal_prep, 'cfde-portal-prep.json')
+registry_schema_json = PackageDataName(registry, 'cfde-registry-model.json')
+
+class PortalPackageDataName (PackageDataName):
+    def get_data(self, key=None):
+        if key is None:
+            key = self.filename
+        buf = super(PortalPackageDataName, self).get_data(key)
+        if key != self.filename:
+            return buf
+        # augment the portal model we return w/ c2m2 submission tables
+        portal_doc = json.loads(buf.decode())
+        portal_resources = portal_doc['resources']
+
+        c2m2_doc = json.loads(submission_schema_json.get_data_str())
+        c2m2_resources = c2m2_doc['resources']
+
+        for resource in c2m2_resources:
+            if 'resourceSchema' in resource:
+                # skip tables not in default CFDE schema...
+                continue
+
+            if resource['name'] in {
+                    'primary_dcc_contact',
+            }:
+                # skip tables we explicitly don't want
+                continue
+
+            # customize resource for use in c2m2 schema of portal
+            resource['resourceSchema'] = 'c2m2'
+            resource['description'] = 'C2M2 formatted %(name)s data' % resource
+            resource['deriva'] = {
+                "indexing_preferences": {
+                    "btree": False,
+                    "trgm": False
+                }
+            }
+            rschema = resource['schema']
+            for field in rschema['fields']:
+                # we don't want c2m2 unique constraints and their implied indices
+                field.get('constraints', {}).pop('unique', None)
+            rschema['fields'] = [
+                {
+                    "name": "nid",
+                    "title": "Numeric ID",
+                    "type": "integer",
+                    "constraints": {
+                        "required": True,
+                        "unique": True
+                    }
+                }
+            ] + [
+                fdoc
+                for fdoc in rschema['fields']
+                # HACK: skip synonyms to reduce DB and export bloat...
+                if fdoc['name'] != 'synonyms'
+            ]
+            rschema['primaryKey'] = [ "nid" ]
+            rschema['foreignKeys'] = [
+                {
+                    "fields": "nid",
+                    "constraint_name": "%(name)s_nid_fkey" % resource,
+                    "reference": {
+                        "resourceSchema": "CFDE",
+                        "resource": resource['name'],
+                        "fields": "nid"
+                    }
+                }
+            ]
+            # add to portal table list
+            portal_resources.append(resource)
+
+        # return as UTF8 bytes to meet get_data() method signature...
+        return json.dumps(portal_doc).encode('utf8')
+
+portal_schema_json = PortalPackageDataName(portal, 'cfde-portal.json')
+
 def acls_union(*sources):
     """Produce union of aclsets"""
     acls = {}
@@ -142,7 +256,7 @@ class CatalogConfigurator (object):
     }
     schema_acls = {
         "CFDE": { "select": [ authn_id.cfde_portal_admin ] },
-        "raw": { "select": [ authn_id.cfde_portal_admin ] },
+        "c2m2": { "select": [ authn_id.cfde_portal_admin ] },
         "public": { "select": [] },
     }
     schema_table_acls = {}
@@ -444,7 +558,7 @@ class ReleaseConfigurator (CatalogConfigurator):
         CatalogConfigurator.schema_acls,
         {
             "CFDE": { "select": ["*"] },
-            "raw": { "select": ["*"] },
+            "c2m2": { "select": ["*"] },
         }
     )
 
@@ -474,7 +588,7 @@ class ReviewConfigurator (CatalogConfigurator):
             CatalogConfigurator.schema_acls,
             {
                 "CFDE": { "select": list(cfde_portal_viewers) },
-                "raw": { "select": list(cfde_portal_viewers) },
+                "c2m2": { "select": list(cfde_portal_viewers) },
             }
         )
         if self.registry is not None and self.submission_id is not None:
@@ -1046,19 +1160,20 @@ def make_model(tableschema, configurator, trusted=False):
 def main():
     """Translate basic Frictionless Table-Schema table definitions to Deriva.
 
-    - Reads table-schema JSON on standard input
+    - Reads builtin table-schema JSON selected by CLI
     - Writes deriva schema JSON on standard output
 
     The output JSON is suitable for POST to an /ermrest/catalog/N/schema
     resource on a fresh, empty catalog.
 
-    Arguments:  [ { 'registry' | 'review' | 'release' } [ 'trusted' ] ]
+    Arguments:  { 'registry' | 'review' | 'release' | 'portal_prep' | 'submission' }
 
     Examples:
 
-    python3 -m cfde_deriva.tableschema release trusted < configs/portal/c2m2-level1-portal-model.json
-    python3 -m cfde_deriva.tableschema review < configs/portal/c2m2-level1-portal-model.json
-    python3 -m cfde_deriva.tableschema registry trusted < configs/registry/cfde-registry-model.json
+    python3 -m cfde_deriva.tableschema release
+    python3 -m cfde_deriva.tableschema review
+    python3 -m cfde_deriva.tableschema registry
+    SKIP_SYSTEM_COLUMNS=true python3 -m cfde_deriva.tableschema etl
 
     Optionally:
 
@@ -1068,21 +1183,30 @@ def main():
 """
     init_logging(logging.INFO)
 
-    if len(sys.argv) < 2:
-        raise ValueError('missing required catalog-type argument: registry | review | release')
+    if len(sys.argv) < 1:
+        raise ValueError('missing required catalog-type argument: registry | review | release | portal_prep | submission')
+
+    buf = {
+        'release': portal_schema_json,
+        'review': portal_schema_json,
+        'registry': registry_schema_json,
+        'portal_prep': portal_prep_schema_json,
+        'submission': submission_schema_json,
+    }[sys.argv[1]].get_data_str()
 
     configurator = {
         'release': ReleaseConfigurator,
         'review': ReviewConfigurator,
         'registry': RegistryConfigurator,
-    }[sys.argv[1]]()
+    }.get(
+        sys.argv[1],
+        # HACK, set default so we can do something for non-catalog schemas
+        ReleaseConfigurator
+    )()
 
-    if len(sys.argv) > 2:
-        trusted = sys.argv[2].lower() == 'trusted'
-    else:
-        trusted = False
+    trusted = True
 
-    json.dump(Model(None, make_model(json.load(sys.stdin), configurator, trusted)).prejson(), sys.stdout, indent=2)
+    json.dump(Model(None, make_model(json.loads(buf), configurator, trusted)).prejson(), sys.stdout, indent=2)
     return 0
 
 if __name__ == '__main__':


### PR DESCRIPTION
Introduces more denormalized content in a separate `c2m2` schema that follows the submission spec while adding the `nid` surrogate key for each row as used in the portal. The bag exports can then more efficiently dump these rows instead of making many joins to try to piece C2M2 fields together from the more normalized content of the portal. Most exports will take much less time and more complex exports become feasible when they would previously hit timeout limits.