### PR TITLE
Support for changes to $session and customizing facet panel display on load

### DIFF
--- a/cfde_deriva/configs/registry/cfde-registry-model.json
+++ b/cfde_deriva/configs/registry/cfde-registry-model.json
@@ -5745,7 +5745,7 @@
                      "markdown_name": "Permissions",
                      "display": {
                        "template_engine": "handlebars",
-                       "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.extensions.has_ras_permissions}}{{#each $session.extensions.ras_dbgap_permissions}}{{#each this}}{{{this.phs_id}}}{{/each}}{{/each}}{{/if}}{{/if}}"
+                       "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{#each $session.client.extensions.ras_dbgap_permissions}}{{#each this}}{{{this.phs_id}}}{{/each}}{{/each}}{{/if}}{{/if}}{{/if}}"
                      }
                   }, {
                      "markdown_name": "Groups",

--- a/cfde_deriva/configs/registry/cfde-registry-model.json
+++ b/cfde_deriva/configs/registry/cfde-registry-model.json
@@ -5733,19 +5733,25 @@
                      "markdown_name": "Email",
                      "display": {
                        "template_engine": "handlebars",
-                       "markdown_pattern": "{{#if (eq $session.id _id)}}{{$session.email}}{{/if}}"
+                       "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{$session.client.email}}{{/if}}"
                      }
                   }, {
                      "markdown_name": "Identities",
                      "display": {
                        "template_engine": "handlebars",
-                       "markdown_pattern": "{{#if (eq $session.id _id)}}{{#each $session.identities}}{{this}}\n{{/each}}{{/if}}"
+                       "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#each $session.client.identities}}{{this}}\n{{/each}}{{/if}}"
+                     }
+                  }, {
+                     "markdown_name": "Permissions",
+                     "display": {
+                       "template_engine": "handlebars",
+                       "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.extensions.has_ras_permissions}}{{#each $session.extensions.ras_dbgap_permissions}}{{#each this}}{{{this.phs_id}}}{{/each}}{{/each}}{{/if}}{{/if}}"
                      }
                   }, {
                      "markdown_name": "Groups",
                      "display": {
                        "template_engine": "handlebars",
-                       "markdown_pattern": "{{#if (eq $session.id _id)}}{{#each $session.attributes}}{{#if (eq this.type 'globus_group')}}[{{this.display_name}}]({{this.webpage}})\n{{/if}}{{/each}}{{/if}}"
+                       "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#each $session.attributes}}{{#if (eq this.type 'globus_group')}}[{{this.display_name}}]({{this.webpage}})\n{{/if}}{{/each}}{{/if}}"
                      }
                   }
                ],

--- a/cfde_deriva/tableschema.py
+++ b/cfde_deriva/tableschema.py
@@ -397,6 +397,9 @@ class CatalogConfigurator (object):
             "SystemColumnsDisplayCompact": [],
             "SystemColumnsDisplayDetailed": [],
             "disableDefaultExport": True,
+            "facetPanelDisplay": {
+                "open": ["compact/select/association"]
+            },
             "savedQueryConfig": {
                 "storageTable": {
                     "catalog": "registry",
@@ -413,7 +416,7 @@ class CatalogConfigurator (object):
                 "menuOptions": [
                     {
                         "nameMarkdownPattern": "My Profile",
-                        "urlPattern": "/chaise/record/#registry/CFDE:user_profile/id={{#encode $session.id}}{{/encode}}",
+                        "urlPattern": "/chaise/record/#registry/CFDE:user_profile/id={{#encode $session.client.id}}{{/encode}}",
                         "type": "url"
                     },
                     {
@@ -422,7 +425,7 @@ class CatalogConfigurator (object):
                         '*::facets::{{#encodeFacet}}'
                         '{"and": [{'
                         '"sourcekey":"S_RCB",'
-                        '"choices":["{{{$session.id}}}"],'
+                        '"choices":["{{{$session.client.id}}}"],'
                         '"source_domain":{"schema":"public","table":"ERMrest_Client","column":"ID"}'
                         '}]}'
                         '{{/encodeFacet}}',


### PR DESCRIPTION
Change templates to use session.client since this changed in ermrestJS. Add another column to visible columns to display extensions information (ras permissions). add another chaise config property to control the default state of the facet panel in the association picker popups