### PR TITLE
Add dbgap study id info to file recordset page

### DIFF
--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -6494,7 +6494,8 @@
                       "comment": "The name of a dbGaP study ID governing access control for this file.",
                       "sourcekey": "S_dbgap_study_id",
                       "display": {
-                         "markdown_pattern": "{{{dbgap_study_id}}}"
+                          "template_engine": "handlebars",
+                          "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc}{{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc}{{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc}{{/if}}{{/if}}{{/if}} {{{dbgap_study_id}}}"
                       }
                   },
                   {
@@ -6549,7 +6550,13 @@
                   {"sourcekey": "S_assay_type"},
                   {"sourcekey": "S_analysis_type"},
                   {"sourcekey": "S_creation_time"},
-                  {"sourcekey": "S_dbgap_study_id"},
+                  {
+                      "sourcekey": "S_dbgap_study_id",
+                      "display": {
+                         "template_engine": "handlebars",
+                         "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc}{{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc}{{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc}{{/if}}{{/if}}{{/if}} {{{dbgap_study_id}}}"
+                      }
+                  },
                   "sha256",
                   "md5"
                ],

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -6495,7 +6495,7 @@
                       "sourcekey": "S_dbgap_study_id",
                       "display": {
                           "template_engine": "handlebars",
-                          "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc}{{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc}{{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc}{{/if}}{{/if}}{{/if}} {{{dbgap_study_id}}}"
+                          "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
                       }
                   },
                   {
@@ -6554,7 +6554,7 @@
                       "sourcekey": "S_dbgap_study_id",
                       "display": {
                          "template_engine": "handlebars",
-                         "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc}{{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc}{{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc}{{/if}}{{/if}}{{/if}} {{{dbgap_study_id}}}"
+                         "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
                       }
                   },
                   "sha256",

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -6497,7 +6497,7 @@
                       "sourcekey": "S_dbgap_study_id",
                       "display": {
                           "template_engine": "handlebars",
-                          "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
+                          "markdown_pattern": "{{#if $session.client}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
                       }
                   },
                   {
@@ -6556,7 +6556,7 @@
                       "sourcekey": "S_dbgap_study_id",
                       "display": {
                          "template_engine": "handlebars",
-                         "markdown_pattern": "{{#if (eq $session.client.id _id)}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
+                         "markdown_pattern": "{{#if $session.client}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
                       }
                   },
                   "sha256",

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -6490,6 +6490,14 @@
                      }
                   },
                   {
+                      "markdown_name": "Dbgap Study Id",
+                      "comment": "The name of a dbGaP study ID governing access control for this file.",
+                      "sourcekey": "S_dbgap_study_id",
+                      "display": {
+                         "markdown_pattern": "{{{dbgap_study_id}}}"
+                      }
+                  },
+                  {
                      "markdown_name": "File Format",
                      "comment": "The content format of the file.",
                      "source": [  {"sourcekey": "S_core_fact"}, "file_format_row" ],

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -6497,7 +6497,7 @@
                       "sourcekey": "S_dbgap_study_id",
                       "display": {
                           "template_engine": "handlebars",
-                          "markdown_pattern": "{{#if $session.client}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
+                          "markdown_pattern": "{{#if $session.client}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{#if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
                       }
                   },
                   {
@@ -6556,7 +6556,7 @@
                       "sourcekey": "S_dbgap_study_id",
                       "display": {
                          "template_engine": "handlebars",
-                         "markdown_pattern": "{{#if $session.client}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
+                         "markdown_pattern": "{{#if $session.client}}{{#if $session.client.extensions}}{{#if $session.client.extensions.has_ras_permissions}}{{#if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id) }}{title=\"User has access to this file.\" .cfde_green_disc} {{else}}{title=\"User does not have access to this file.\" .cfde_yellow_disc} {{/if}}{{else}}{title=\"User access to this file undetermined, check log in credentials.\" .cfde_grey_disc} {{/if}}{{/if}}{{/if}}{{{dbgap_study_id}}}"
                       }
                   },
                   "sha256",


### PR DESCRIPTION
This PR intends to add the dbgap study id information as a column in the File table recordset view after `Project` and before `File Format`.

I used the same "display name" that is displayed in record page. I used the same tooltip too as the comment but truncated it to remove some extra text. Tooltip used for record page:
 - "The name of a dbGaP study ID governing access control for this file, compatible for comparison to RAS user-level access control metadata"
 
I attached a markdown pattern for the dbgap study id to show the file access info for the current logged in user to the file recordset and record displays. The template should read as following:
```
if $session.client:
  if $session.client.extensions:
    if $session.client.extensions.has_ras_permissions:
      if (lookup $session.extensions.ras_dbgap_phs_ids dbgap_study_id):
        green circle - User has access to this file.
      else:
        yellow circle - User does not have access to this file.
      endif
    else:
      // extensions defined but has_ras_permissions is false
      grey circle - User access to this file undetermined, check log in credentials.
    endif
  endif
endif
```