### PR TITLE
C2M2 sample_prep_method

### DIFF
--- a/cfde_deriva/__init__.py
+++ b/cfde_deriva/__init__.py
@@ -1,7 +1,7 @@
 
 # not much here
 
-__version__ = '5.0'
+__version__ = '6.0'
 
 # use the modules you want...
 

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -304,7 +304,7 @@
                   },
                   "S_collection": {
                      "markdown_name": "Collection",
-                     "comment": "Cllections referencing this assay type.",
+                     "comment": "Collections referencing this assay type.",
                      "source": [
                         {"sourcekey": "S_core_fact"},
                         {"inbound": ["CFDE", "collection_core_fact_fkey"]},
@@ -346,6 +346,192 @@
             "visible_foreign_keys": {
                "*": [
                   {"sourcekey": "S_file"}
+               ]
+            }
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "sample_prep_method",
+         "title": "Sample Prep Method",
+         "description": "List of Ontology for Biomedical Investigations (OBI) CV terms used to describe types of preparation methods that produce C2M2 biosamples",
+         "schema": {
+            "fields": [
+               {
+                  "name": "nid",
+                  "title": "Numeric ID",
+                  "description": "Numeric, surrogate key representing this sample_prep_method in the portal.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  },
+                  "deriva": {
+                     "acls": {
+                        "update": []
+                     }
+                  }
+               },
+               {
+                  "name": "id",
+                  "description": "An OBI CV term",
+                  "type": "string",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  },
+                  "deriva": {
+                     "acls": {
+                        "update": []
+                     }
+                  }
+               },
+               {
+                  "name": "name",
+                  "description": "A short, human-readable, machine-read-friendly label for this OBI term",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  },
+                  "deriva": {
+                     "acls": {
+                        "update": []
+                     }
+                  }
+               },
+               {
+                  "name": "description",
+                  "description": "A human-readable description of this OBI term",
+                  "type": "string",
+                  "deriva": {
+                     "acls": {
+                        "update": []
+                     }
+                  }
+               },
+               {
+                  "name": "synonyms",
+                  "description": "A list of synonyms for this term as identified by the OBI metadata",
+                  "type": "array",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": []
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": "nid"
+         },
+         "deriva": {
+            "acls": {
+               "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+            },
+            "immutable": true,
+            "table_config": {
+               "stable_key_columns": ["id"],
+               "user_favorites_disabled": {
+                  "storage_table": {
+                     "catalog": "registry",
+                     "schema": "CFDE",
+                     "table": "favorite_sample_prep_method",
+                     "favorited_key_columns": ["sample_prep_method"],
+                     "user_id_column": "user_id"
+                  }
+               }
+            },
+            "source_definitions": {
+               "columns": true,
+               "fkeys": true,
+               "sources": {
+                  "S_core_fact": {
+                     "source": [
+                        {"inbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_biosample": {
+                     "markdown_name": "Biosample",
+                     "comment": "Biosamples referencing this sample prep method.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "biosample_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_subject": {
+                     "markdown_name": "Subject",
+                     "comment": "Subjects referencing this sample prep method.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "subject_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_collection": {
+                     "markdown_name": "Collection",
+                     "comment": "Collections referencing this sample prep method.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "collection_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  },
+                  "S_file": {
+                     "markdown_name": "File",
+                     "comment": "Files referencing this sample prep method.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "file_core_fact_fkey"]},
+                        "nid"
+                     ]
+                  }
+               }
+            },
+            "visible_columns": {
+               "*": [
+                  "id",
+                  "name",
+                  "description",
+                  {"source": "resource_markdown", "hide_column_header": true}
+               ],
+               "compact": [
+                  "id",
+                  "name",
+                  "description"
+               ],
+               "filter": {"and": [
+                  {"source": "id"},
+                  {"source": "name"},
+                  {"sourcekey": "S_collection"},
+                  {"sourcekey": "S_file"},
+                  {"sourcekey": "S_biosample"},
+                  {"sourcekey": "S_subject"}
+               ]}
+            },
+            "visible_foreign_keys": {
+               "*": [
+                  {"sourcekey": "S_biosample"}
                ]
             }
          }
@@ -4862,6 +5048,22 @@
                   }
                },
                {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
+                  "type": "array",
+                  "format": "integer",
+                  "constraints": {
+                     "required": true
+                  },
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": false,
+                        "gin_array": true
+                     }
+                  }
+               },
+               {
                   "name": "assay_types",
                   "description": "The numeric ID of assay_type terms qualifying the described entities.",
                   "type": "array",
@@ -5282,6 +5484,16 @@
                            {
                               "source": {
                                  "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_sample_prep_method/(sample_prep_method)=(c2m2:sample_prep_method:nid)"
+                              },
+                              "destination": {
+                                 "name": "sample_prep_method",
+                                 "type": "csv"
+                              }
+                           },
+                           {
+                              "source": {
+                                 "api": "entity",
                                  "path": "(core_fact)/CFDE:core_fact_assay_type/(assay_type)=(c2m2:assay_type:nid)"
                               },
                               "destination": {
@@ -5679,6 +5891,15 @@
                         "nid"
                      ]
                   },
+                  "S_sample_prep_method": {
+                     "comment": "Sample prep method of a consistuent biosample.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_assay_type": {
                      "comment": "Assay type of a constituent file, offering original terms and corresponding \"slim\" terms.",
                      "source": [
@@ -5993,6 +6214,7 @@
                   {"sourcekey": "S_file_format"},
                   {"sourcekey": "S_assay_type_slim"},
                   {"sourcekey": "S_assay_type"},
+                  {"sourcekey": "S_sample_prep_method"},
                   {"sourcekey": "S_anatomy_slim", "open": true},
                   {"sourcekey": "S_anatomy"},
                   {"sourcekey": "S_ncbi_taxons_slim"},
@@ -6312,6 +6534,22 @@
                {
                   "name": "anatomies",
                   "description": "The numeric ID of anatomy terms qualifying the described entities.",
+                  "type": "array",
+                  "format": "integer",
+                  "constraints": {
+                     "required": true
+                  },
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": false,
+                        "gin_array": true
+                     }
+                  }
+               },
+               {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
                   "type": "array",
                   "format": "integer",
                   "constraints": {
@@ -6651,6 +6889,16 @@
                               },
                               "destination": {
                                  "name": "data_type",
+                                 "type": "csv"
+                              }
+                           },
+                           {
+                              "source": {
+                                 "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_sample_prep_method/(sample_prep_method)=(c2m2:sample_prep_method:nid)"
+                              },
+                              "destination": {
+                                 "name": "sample_prep_method",
                                  "type": "csv"
                               }
                            },
@@ -7114,8 +7362,17 @@
                         "nid"
                      ]
                   },
+                  "S_sample_prep_method": {
+                     "comment": "Sample prep method of related biosamples.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_assay_type": {
-                     "comment": "Assay type of the file or related biosamples, offering original terms and corresponding \"slim\" terms.",
+                     "comment": "Assay type of a file, offering original terms and corresponding \"slim\" terms.",
                      "source": [
                         {"sourcekey": "S_core_fact"},
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
@@ -7125,7 +7382,7 @@
                   },
                   "S_assay_type_slim": {
                      "markdown_name": "Assay Type (slim)",
-                     "comment": "Assay type of the file or related biosamples, offering only \"slim\" terms corresponding to original metadata.",
+                     "comment": "Assay type of a file, offering only \"slim\" terms corresponding to original metadata.",
                      "source": [
                         {"sourcekey": "S_core_fact"},
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
@@ -7450,6 +7707,7 @@
                   {"sourcekey": "S_assay_type_slim"},
                   {"sourcekey": "S_assay_type"},
                   {"sourcekey": "S_analysis_type"},
+                  {"sourcekey": "S_sample_prep_method"},
                   {"sourcekey": "S_anatomy_slim", "open": true},
                   {"sourcekey": "S_anatomy"},
                   {"sourcekey": "S_taxonomy_slim"},
@@ -7796,6 +8054,22 @@
                   }
                },
                {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
+                  "type": "array",
+                  "format": "integer",
+                  "constraints": {
+                     "required": true
+                  },
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": false,
+                        "gin_array": true
+                     }
+                  }
+               },
+               {
                   "name": "assay_types",
                   "description": "The numeric ID of assay_type terms qualifying the described entities.",
                   "type": "array",
@@ -8080,6 +8354,16 @@
                            {
                               "source": {
                                  "api": "entity",
+                                 "path": "(core_fact)/CFDE:core_fact_sample_prep_method/(sample_prep_method)=(c2m2:sample_prep_method:nid)"
+                              },
+                              "destination": {
+                                 "name": "sample_prep_method",
+                                 "type": "csv"
+                              }
+                           },
+                           {
+                              "source": {
+                                 "api": "entity",
                                  "path": "(core_fact)/CFDE:core_fact_assay_type/(assay_type)=(c2m2:assay_type:nid)"
                               },
                               "destination": {
@@ -8353,8 +8637,17 @@
                         "nid"
                      ]
                   },
+                  "S_sample_prep_method": {
+                     "comment": "Sample prep method of a biosample.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_assay_type": {
-                     "comment": "Assay type of a biosample or related files, offering original terms and corresponding \"slim\" terms.",
+                     "comment": "Assay type of related files, offering original terms and corresponding \"slim\" terms.",
                      "source": [
                         {"sourcekey": "S_core_fact"},
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
@@ -8364,7 +8657,7 @@
                   },
                   "S_assay_type_slim": {
                      "markdown_name": "Assay Type (slim)",
-                     "comment": "Assay type of a biosample or related files, offering only \"slim\" terms corresponding to original metadata.",
+                     "comment": "Assay type of related files, offering only \"slim\" terms corresponding to original metadata.",
                      "source": [
                         {"sourcekey": "S_core_fact"},
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
@@ -8373,12 +8666,12 @@
                         "nid"
                      ]
                   },
-                  "S_assay_type_local": {
-                     "markdown_name": "Assay Type",
-                     "comment": "The assay-type which prepared the biosample.",
+                  "S_sample_prep_method_local": {
+                     "markdown_name": "Sample Prep Method",
+                     "comment": "The sample prep method for the biosample.",
                      "source": [
                         {"sourcekey": "S_core_fact"},
-                        {"outbound": ["CFDE", "core_fact_assay_type_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_sample_prep_method_fkey"]},
                         "nid"
                      ]
                   },
@@ -8653,9 +8946,9 @@
                      }
                   },
                   {
-                     "markdown_name": "Assay Type",
-                     "comment": "The assay type of the biosample.",
-                     "source": ["S_core_fact", "assay_type_row"],
+                     "markdown_name": "Sample Prep Method",
+                     "comment": "The sample prep method of the biosample.",
+                     "source": ["S_core_fact", "sample_prep_method_row"],
                      "display": {
                         "markdown_pattern": "{{{$_self.name}}}"
                      }
@@ -8670,7 +8963,7 @@
                   "local_id",
                   "persistent_id",
                   {"sourcekey": "S_project"},
-                  {"sourcekey": "S_assay_type_local"},
+                  {"sourcekey": "S_sample_prep_method_local"},
                   {"sourcekey": "S_anatomy"},
                   {
                      "sourcekey": "S_disease",
@@ -8689,10 +8982,11 @@
                   {"sourcekey": "S_creation_time"}
                ],
                "filter": {"and": [
-                  {"sourcekey": "S_assay_type_slim", "open": true},
-                  {"sourcekey": "S_assay_type"},
+                  {"sourcekey": "S_sample_prep_method", "open": true},
                   {"sourcekey": "S_anatomy_slim", "open": true},
                   {"sourcekey": "S_anatomy"},
+                  {"sourcekey": "S_assay_type_slim", "open": true},
+                  {"sourcekey": "S_assay_type"},
                   {"sourcekey": "S_taxonomy_slim"},
                   {"sourcekey": "S_taxonomy"},
                   {"sourcekey": "S_disease_search_slim"},
@@ -9022,6 +9316,22 @@
                {
                   "name": "anatomies",
                   "description": "The numeric ID of anatomy terms qualifying the described entities.",
+                  "type": "array",
+                  "format": "integer",
+                  "constraints": {
+                     "required": true
+                  },
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": false,
+                        "gin_array": true
+                     }
+                  }
+               },
+               {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
                   "type": "array",
                   "format": "integer",
                   "constraints": {
@@ -9751,8 +10061,17 @@
                         "nid"
                      ]
                   },
+                  "S_sample_prep_method": {
+                     "comment": "Sample prep method of a biosample.",
+                     "source": [
+                        {"sourcekey": "S_core_fact"},
+                        {"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
+                        {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
+                        "nid"
+                     ]
+                  },
                   "S_assay_type": {
-                     "comment": "Assay type of a file or related biosamples, offering original terms and corresponding \"slim\" terms.",
+                     "comment": "Assay type of a file, offering original terms and corresponding \"slim\" terms.",
                      "source": [
                         {"sourcekey": "S_core_fact"},
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
@@ -9762,7 +10081,7 @@
                   },
                   "S_assay_type_slim": {
                      "markdown_name": "Assay Type (slim)",
-                     "comment": "Assay type of a file or related biosamples, offering only \"slim\" terms corresponding to original metadata.",
+                     "comment": "Assay type of a file, offering only \"slim\" terms corresponding to original metadata.",
                      "source": [
                         {"sourcekey": "S_core_fact"},
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
@@ -9951,6 +10270,7 @@
                   {"sourcekey": "S_role"},
                   {"sourcekey": "S_anatomy_slim"},
                   {"sourcekey": "S_anatomy"},
+                  {"sourcekey": "S_sample_prep_method"},
                   {"sourcekey": "S_assay_type_slim"},
                   {"sourcekey": "S_assay_type"},
                   {"sourcekey": "S_data_type_slim"},
@@ -12493,6 +12813,22 @@
                },
 
                {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
+                  "type": "array",
+                  "format": "integer",
+                  "constraints": {
+                     "required": true
+                  },
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": false,
+                        "gin_array": true
+                     }
+                  }
+               },
+               {
                   "name": "assay_types",
                   "description": "The numeric ID of assay_type terms qualifying the described entities.",
                   "type": "array",
@@ -12672,6 +13008,17 @@
                   }
                },
                {
+                  "name": "sample_prep_method",
+                  "description": "The numeric ID of the sample_prep_method term qualifying the described files.",
+                  "type": "integer",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": ["sample_prep_method", "nid"],
+                        "trgm": false
+                     }
+                  }
+               },
+               {
                   "name": "assay_type",
                   "description": "The numeric ID of the assay_type term qualifying the described files.",
                   "type": "integer",
@@ -12771,6 +13118,11 @@
                {
                   "name": "anatomy_row",
                   "description": "Denormalized copy of the anatomy term qualifying the described biosamples.",
+                  "type": "object"
+               },
+               {
+                  "name": "sample_prep_method_row",
+                  "description": "Denormalized copy of the sample_prep_method term qualifying the described files.",
                   "type": "object"
                },
                {
@@ -12895,6 +13247,14 @@
                   }
                },
                {
+                  "fields": "sample_prep_method",
+                  "constraint_name": "core_fact_sample_prep_method_fkey",
+                  "reference": {
+                     "resource": "sample_prep_method",
+                     "fields": "nid"
+                  }
+               },
+               {
                   "fields": "assay_type",
                   "constraint_name": "core_fact_assay_type_fkey",
                   "reference": {
@@ -12979,6 +13339,10 @@
                      "comment": "An ethnicity CV term associated with a set of C2M2 entities.",
                      "source": [{"inbound": ["CFDE", "core_fact_ethnicity_core_fact_fkey"]}, {"outbound": ["CFDE", "core_fact_ethnicity_ethnicity_fkey"]}, "nid"]
                   },
+                  "S_sample_prep_methods": {
+                     "comment": "A sample prep method CV term associated with a set of C2M2 entities.",
+                     "source": [{"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]}, {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]}, "nid"]
+                  },
                   "S_assay_types": {
                      "comment": "An assay-type CV term associated with a set of C2M2 entities.",
                      "source": [{"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]}, {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]}, "nid"]
@@ -13032,6 +13396,7 @@
                   {"sourcekey": "S_projects"},
                   {"sourcekey": "S_diseases"},
                   {"sourcekey": "S_assay_types"},
+                  {"sourcekey": "S_sample_prep_methods"},
                   {"sourcekey": "S_data_types"},
                   {"sourcekey": "S_file_formats"},
                   {"sourcekey": "S_compression_formats"},
@@ -13066,6 +13431,15 @@
                      "display": {
                         "template_engine": "handlebars",
                         "markdown_pattern": "{{#if (gt _assay_types.length \"1\")}}{{_assay_types.length}} values{{else}}{{#if $fkeys.CFDE.core_fact_assay_type_fkey}}{{{$fkeys.CFDE.core_fact_assay_type_fkey.rowName}}}{{else}}{{/if}}{{/if}}"
+                     }
+                  },
+                  {
+                     "markdown_name": "Sample Prep Method",
+                     "source": "sample_prep_methods",
+                     "comment": "Sample prep method to which a set of C2M2 entities is attributed.",
+                     "display": {
+                        "template_engine": "handlebars",
+                        "markdown_pattern": "{{#if (gt _sample_prep_methods.length \"1\")}}{{_sample_prep_methods.length}} values{{else}}{{#if $fkeys.CFDE.core_fact_sample_prep_method_fkey}}{{{$fkeys.CFDE.core_fact_sample_prep_method_fkey.rowName}}}{{else}}{{/if}}{{/if}}"
                      }
                   },
                   {
@@ -13127,6 +13501,7 @@
                   {"sourcekey": "S_dccs"},
                   {"sourcekey": "S_projects"},
                   {"sourcekey": "S_assay_types"},
+                  {"sourcekey": "S_sample_prep_methods"},
                   {"sourcekey": "S_data_types"},
                   {"sourcekey": "S_file_formats"},
                   {"sourcekey": "S_compression_formats"},
@@ -14609,6 +14984,57 @@
                   "constraint_name": "core_fact_anatomy_anatomy_fkey",
                   "reference": {
                      "resource": "anatomy",
+                     "fields": "nid"
+                  }
+               }
+            ]
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "core_fact_sample_prep_method",
+         "description": "An exploded representation of the core_fact.sample_prep_methods array column as a binary association.",
+         "schema": {
+            "fields": [
+               {
+                  "name": "core_fact",
+                  "title": "Numeric ID",
+                  "description": "The numeric ID of a core_fact record in the portal.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "sample_prep_method",
+                  "description": "The numeric ID of a term found in the core_fact.sample_prep_methods array column.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true
+                  },
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": ["sample_prep_method", "core_fact"],
+                        "trgm": false
+                     }
+                  }
+               }
+            ],
+            "primaryKey": ["core_fact", "sample_prep_method"],
+            "foreignKeys": [
+               {
+                  "fields": "core_fact",
+                  "constraint_name": "core_fact_sample_prep_method_core_fact_fkey",
+                  "reference": {
+                     "resource": "core_fact",
+                     "fields": "nid"
+                  }
+               },
+               {
+                  "fields": "sample_prep_method",
+                  "constraint_name": "core_fact_sample_prep_method_sample_prep_method_fkey",
+                  "reference": {
+                     "resource": "sample_prep_method",
                      "fields": "nid"
                   }
                }

--- a/cfde_deriva/configs/portal_prep/cfde-portal-prep.json
+++ b/cfde_deriva/configs/portal_prep/cfde-portal-prep.json
@@ -666,6 +666,72 @@
          },
          "derivation_sql_path": null
       },
+
+      {
+         "profile": "tabular-data-resource",
+         "name": "sample_prep_method",
+         "title": "sample_prep_method",
+         "dialect": {
+            "delimiter": "\t",
+            "doubleQuote": false,
+            "lineTerminator": "\n",
+            "skipInitialSpace": true,
+            "header": true
+         },
+         "description": "List of Ontology for Biomedical Investigations (OBI) CV terms used to describe types of preparation methods that produce C2M2 biosamples",
+         "schema": {
+            "fields": [
+               {
+                  "name": "nid",
+                  "title": "Numeric ID",
+                  "description": "Numeric, surrogate key representing this sample_prep_method in the portal.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  }
+               },
+               {
+                  "name": "id",
+                  "description": "An OBI CV term",
+                  "type": "string",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  }
+               },
+               {
+                  "name": "name",
+                  "description": "A short, human-readable, machine-read-friendly label for this OBI term",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "description",
+                  "description": "A human-readable description of this OBI term",
+                  "type": "string"
+               },
+               {
+                  "name": "synonyms",
+                  "description": "A list of synonyms for this term as identified by the OBI metadata",
+                  "type": "array"
+               },
+               {
+                  "name": "resource_markdown",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown"
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": "nid"
+         },
+         "derivation_sql_path": null
+      },
+
+      
       {
          "profile": "tabular-data-resource",
          "name": "analysis_type",
@@ -2463,6 +2529,11 @@
                   "type": "array"
                },
                {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
+                  "type": "array"
+               },
+               {
                   "name": "assay_types",
                   "description": "The numeric ID of assay_type terms qualifying the described entities.",
                   "type": "array"
@@ -2777,6 +2848,11 @@
                   "type": "array"
                },
                {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
+                  "type": "array"
+               },
+               {
                   "name": "assay_types",
                   "description": "The numeric ID of assay_type terms qualifying the described entities.",
                   "type": "array"
@@ -3082,8 +3158,8 @@
                   }
                },
                {
-                  "name": "assay_type",
-                  "description": "Numeric ID for assay_type term ID describing the type of experiment that generated this biosample",
+                  "name": "sample_prep_method",
+                  "description": "Numeric ID for an OBI CV term ID (from the 'planned process' branch of the vocabulary, excluding the 'assay' subtree) describing the preparation method that produced this biosample",
                   "type": "integer"
                },
                {
@@ -3165,6 +3241,11 @@
                {
                   "name": "anatomies",
                   "description": "The numeric ID of anatomy terms qualifying the described entities.",
+                  "type": "array"
+               },
+               {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
                   "type": "array"
                },
                {
@@ -3306,10 +3387,10 @@
                   }
                },
                {
-                  "fields": "assay_type",
-                  "constraint_name": "biosample_assay_type_fkey",
+                  "fields": "sample_prep_method",
+                  "constraint_name": "biosample_sample_prep_method_fkey",
                   "reference": {
-                     "resource": "assay_type",
+                     "resource": "sample_prep_method",
                      "fields": "nid"
                   }
                },
@@ -3478,6 +3559,11 @@
                {
                   "name": "anatomies",
                   "description": "The numeric ID of anatomy terms qualifying the described entities.",
+                  "type": "array"
+               },
+               {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
                   "type": "array"
                },
                {
@@ -5674,6 +5760,14 @@
                      "required": true
                   }
                },
+               {
+                  "name": "sample_prep_methods",
+                  "description": "The numeric ID of sample_prep_method terms qualifying the described entities.",
+                  "type": "array",
+                  "constraints": {
+                     "required": true
+                  }
+               },
 
                {
                   "name": "assay_types",
@@ -5763,6 +5857,11 @@
                   "type": "integer"
                },
                {
+                  "name": "sample_prep_method",
+                  "description": "Numeric ID of the sample_prep_method term qualifying the described biosamples.",
+                  "type": "integer"
+               },
+               {
                   "name": "assay_type",
                   "description": "The numeric ID of the assay_type term qualifying the described files.",
                   "type": "integer"
@@ -5826,6 +5925,11 @@
                {
                   "name": "anatomy_row",
                   "description": "Denormalized copy of the anatomy term qualifying the described biosamples.",
+                  "type": "object"
+               },
+               {
+                  "name": "sample_prep_method_row",
+                  "description": "Denormalized copy of the sample_prep_method term qualifying the described biosamples.",
                   "type": "object"
                },
                {
@@ -5907,6 +6011,7 @@
                "ethnicity",
                "subject_granularity",
                "anatomy",
+               "sample_prep_method",
                "assay_type",
                "analysis_type",
                "file_format",
@@ -5927,6 +6032,7 @@
                "subject_species",
                "ncbi_taxons",
                "anatomies",
+               "sample_prep_methods",
                "assay_types",
                "analysis_types",
                "file_formats",
@@ -7055,6 +7161,52 @@
                   "constraint_name": "core_fact_anatomy_anatomy_fkey",
                   "reference": {
                      "resource": "anatomy",
+                     "fields": "nid"
+                  }
+               }
+            ]
+         },
+         "derivation_sql_path": null
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "core_fact_sample_prep_method",
+         "description": "An exploded representation of the core_fact.sample_prep_methods array column as a binary association.",
+         "schema": {
+            "fields": [
+               {
+                  "name": "core_fact",
+                  "title": "Numeric ID",
+                  "description": "The numeric ID of a core_fact record in the portal.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "sample_prep_method",
+                  "description": "The numeric ID of a term found in the core_fact.sample_prep_methods array column.",
+                  "type": "integer",
+                  "constraints": {
+                     "required": true
+                  }
+               }
+            ],
+            "primaryKey": ["core_fact", "sample_prep_method"],
+            "foreignKeys": [
+               {
+                  "fields": "core_fact",
+                  "constraint_name": "core_fact_sample_prep_method_core_fact_fkey",
+                  "reference": {
+                     "resource": "core_fact",
+                     "fields": "nid"
+                  }
+               },
+               {
+                  "fields": "sample_prep_method",
+                  "constraint_name": "core_fact_sample_prep_method_sample_prep_method_fkey",
+                  "reference": {
+                     "resource": "sample_prep_method",
                      "fields": "nid"
                   }
                }

--- a/cfde_deriva/configs/registry/cfde-registry-model.json
+++ b/cfde_deriva/configs/registry/cfde-registry-model.json
@@ -1166,6 +1166,16 @@
                      ],
                      "entity": true
                   },
+                  "S_sample_prep_method": {
+                     "markdown_name": "Sample Prep Method",
+                     "comment": "Sample prep method terms used in submission",
+                     "source": [
+                        {"inbound": ["CFDE", "datapackage_sample_prep_method_datapackage_fkey"]},
+                        {"outbound": ["CFDE", "datapackage_sample_prep_method_sample_prep_method_fkey"]},
+                        "id"
+                     ],
+                     "entity": true
+                  },
                   "S_analysis_type": {
                      "markdown_name": "Analysis Type",
                      "comment": "Analysis type terms used in submission",
@@ -1365,6 +1375,7 @@
                   {"sourcekey": "S_datapackage_measurements"},
                   {"sourcekey": "S_analysis_type"},
                   {"sourcekey": "S_anatomy"},
+                  {"sourcekey": "S_sample_prep_method"},
                   {"sourcekey": "S_assay_type"},
                   {"sourcekey": "S_compound"},
                   {"sourcekey": "S_data_type"},
@@ -1444,6 +1455,7 @@
                   {"sourcekey": "S_release_statuses"},
                   {"source": "submission_time"},
                   {"sourcekey": "S_anatomy"},
+                  {"sourcekey": "S_sample_prep_method"},
                   {"sourcekey": "S_assay_type"},
                   {"sourcekey": "S_data_type"},
                   {"sourcekey": "S_file_format"},
@@ -2319,6 +2331,105 @@
                {
                   "name": "synonyms",
                   "description": "A list of human-readable synonyms for this term",
+                  "type": "array",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     }
+                  }
+               },
+               {
+                  "name": "resource_markdown",
+                  "title": "Resources",
+                  "description": "External resource information pre-formatted as markdown",
+                  "type": "string",
+                  "format": "markdown",
+                  "deriva": {
+                     "indexing_preferences": {
+                        "btree": false,
+                        "trgm": true
+                     },
+                     "acls": {
+                        "update": [ "cfde_portal_admin", "cfde_portal_curator" ]
+                     }
+                  }
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": "id"
+         },
+         "deriva": {
+            "acls": {
+               "select": [ "*" ],
+               "insert": [ "cfde_portal_admin", "cfde_portal_curator", "cfde_submission_pipeline" ],
+               "update": [ "cfde_portal_admin", "cfde_portal_curator", "cfde_submission_pipeline" ],
+               "delete": [ "cfde_portal_admin", "cfde_portal_curator" ]
+            },
+            "source_definitions": {
+               "columns": true,
+               "fkeys": true,
+               "sources": {
+               }
+            },
+            "visible_columns": {
+               "*": [
+                  "id",
+                  "name",
+                  "description",
+                  "resource_markdown"
+               ],
+               "compact": [
+                  "id",
+                  "name",
+                  "description"
+               ]
+            },
+            "visible_foreign_keys": {
+               "*": [
+               ]
+            }
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "sample_prep_method",
+         "title": "sample_prep_method",
+         "dialect": {
+            "delimiter": "\t",
+            "doubleQuote": false,
+            "lineTerminator": "\n",
+            "skipInitialSpace": true,
+            "header": true
+         },
+         "description": "List of Ontology for Biomedical Investigations (OBI) CV terms used to describe types of preparation methods that produce C2M2 biosamples",
+         "schema": {
+            "fields": [
+               {
+                  "name": "id",
+                  "description": "An OBI CV term",
+                  "type": "string",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  }
+               },
+               {
+                  "name": "name",
+                  "description": "A short, human-readable, machine-read-friendly label for this OBI term",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "description",
+                  "description": "A human-readable description of this OBI term",
+                  "type": "string"
+               },
+               {
+                  "name": "synonyms",
+                  "description": "A list of synonyms for this term as identified by the OBI metadata",
                   "type": "array",
                   "deriva": {
                      "indexing_preferences": {
@@ -4167,6 +4278,78 @@
                   "types": ["select"],
                   "projection": [
                      {"outbound": ["CFDE", "datapackage_anatomy_datapackage_fkey"]},
+                     {"outbound": ["CFDE", "datapackage_submitting_dcc_fkey"]},
+                     {"inbound": ["CFDE", "dcc_group_role_dcc_fkey"]},
+                     {"outbound": ["CFDE", "dcc_group_role_group_fkey"]},
+                     "webauthn_id"
+                  ],
+                  "projection_type": "acl",
+                  "scope_acl": ["*"]
+               }
+            }
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "datapackage_sample_prep_method",
+         "title": "Datapackage Sample Prep Method",
+         "description": "An association of an sample_prep_method term used by a datapackage submission.",
+         "schema": {
+            "fields": [
+               {
+                  "name": "datapackage",
+                  "description": "The datapackage ID which uses the term.",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "sample_prep_method",
+                  "description": "The referenced sample_prep_method term ID.",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": ["datapackage", "sample_prep_method"],
+            "foreignKeys": [
+               {
+                  "fields": "datapackage",
+                  "constraint_name": "datapackage_sample_prep_method_datapackage_fkey",
+                  "reference": {
+                     "resource": "datapackage",
+                     "fields": "id"
+                  },
+                  "on_update": "CASCADE",
+                  "on_delete": "CASCADE"
+               },
+               {
+                  "fields": "sample_prep_method",
+                  "constraint_name": "datapackage_sample_prep_method_sample_prep_method_fkey",
+                  "reference": {
+                     "resource": "sample_prep_method",
+                     "fields": "id"
+                  },
+                  "on_update": "CASCADE",
+                  "on_delete": "CASCADE"
+               }
+            ]
+         },
+         "deriva": {
+            "acls": {
+               "select": [ "cfde_portal_admin", "cfde_portal_curator", "cfde_submission_pipeline", "cfde_portal_reviewer" ],
+               "insert": [ "cfde_portal_admin", "cfde_portal_curator", "cfde_submission_pipeline" ],
+               "update": [ "cfde_portal_admin", "cfde_portal_curator" ],
+               "delete": [ "cfde_portal_admin", "cfde_portal_curator" ]
+            },
+            "acl_bindings": {
+               "dcc_group_any": {
+                  "types": ["select"],
+                  "projection": [
+                     {"outbound": ["CFDE", "datapackage_sample_prep_method_datapackage_fkey"]},
                      {"outbound": ["CFDE", "datapackage_submitting_dcc_fkey"]},
                      {"inbound": ["CFDE", "dcc_group_role_dcc_fkey"]},
                      {"outbound": ["CFDE", "dcc_group_role_group_fkey"]},
@@ -6347,6 +6530,97 @@
                   "reference": {
                      "title": "Favorite Anatomy",
                      "resource": "anatomy",
+                     "fields": "id"
+                  },
+                  "on_update": "CASCADE",
+                  "on_delete": "CASCADE"
+               }
+            ]
+         },
+         "deriva": {
+            "acls": {
+               "select": [ "cfde_portal_admin" ],
+               "insert": [ "cfde_portal_admin", "cfde_portal_members", "cfde_portal_curator", "cfde_portal_reviewer", "cfde_portal_writer", "cfde_portal_reader" ],
+               "update": [ "cfde_portal_admin" ],
+               "delete": [ "cfde_portal_admin" ]
+            },
+            "acl_bindings": {
+               "profile_owner": {
+                  "types": ["select", "update", "delete"],
+                  "projection": [
+                     "user_id"
+                  ],
+                  "projection_type": "acl",
+                  "scope_acl": ["*"]
+               }
+            }
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "favorite_sample_prep_method",
+         "title": "Favorite Sample Prep Method",
+         "description": "An association of a favorited sample_prep_method term in a specific user profile.",
+         "schema": {
+            "fields": [
+               {
+                  "name": "user_id",
+                  "description": "The authentication system ID for the user.",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  },
+                  "deriva": {
+                     "acls": {
+                        "select": ["*"],
+                        "update": []
+                     },
+                     "acl_bindings": {
+                        "profile_owner": false
+                     }
+                  }
+               },
+               {
+                  "name": "sample_prep_method",
+                  "description": "The favorited sample_prep_method term ID.",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": ["user_id", "sample_prep_method"],
+            "foreignKeys": [
+               {
+                  "fields": "user_id",
+                  "constraint_name": "favorite_sample_prep_method_user_id_fkey",
+                  "reference": {
+                     "resource": "user_profile",
+                     "fields": "id"
+                  },
+                  "on_update": "CASCADE",
+                  "on_delete": "CASCADE",
+                  "deriva": {
+                     "acls": {
+                        "insert": [ "cfde_portal_admin" ]
+                     },
+                     "acl_bindings": {
+                        "self": {
+                           "types": ["insert"],
+                           "projection": [ "id" ],
+                           "projection_type": "acl",
+                           "scope_acl": ["*"]
+                        }
+                     }
+                  }
+               },
+               {
+                  "fields": "sample_prep_method",
+                  "constraint_name": "favorite_sample_prep_method_sample_prep_method_fkey",
+                  "reference": {
+                     "title": "Favorite Sample Prep Method",
+                     "resource": "sample_prep_method",
                      "fields": "id"
                   },
                   "on_update": "CASCADE",

--- a/cfde_deriva/configs/submission/c2m2-datapackage.json
+++ b/cfde_deriva/configs/submission/c2m2-datapackage.json
@@ -263,8 +263,13 @@
                   "format": "any"
                },
                {
+                  "name": "sample_prep_method",
+                  "description": "An OBI CV term ID (from the 'planned process' branch of the vocabulary, excluding the 'assay' subtree) describing the preparation method that produced this biosample",
+                  "type": "string"
+               },
+               {
                   "name": "assay_type",
-                  "description": "An OBI CV term ID describing the type of experiment that generated this biosample",
+                  "description": "DEPRECATED FIELD left temporarily for backwards-compatibility",
                   "type": "string"
                },
                {
@@ -292,14 +297,16 @@
                   }
                },
                {
-                  "fields": "assay_type",
+                  "fields": "sample_prep_method",
+                  "constraint_name": "biosample_sample_prep_method_fkey",
                   "reference": {
-                     "resource": "assay_type",
+                     "resource": "sample_prep_method",
                      "fields": "id"
                   }
                },
                {
                   "fields": "anatomy",
+                  "constraint_name": "biosample_anatomy_fkey",
                   "reference": {
                      "resource": "anatomy",
                      "fields": "id"
@@ -3288,6 +3295,52 @@
                   }
                }
             ]
+         }
+      },
+      {
+         "profile": "tabular-data-resource",
+         "name": "sample_prep_method",
+         "title": "sample_prep_method",
+         "dialect": {
+            "delimiter": "\t",
+            "doubleQuote": false,
+            "lineTerminator": "\n",
+            "skipInitialSpace": true,
+            "header": true
+         },
+         "description": "List of Ontology for Biomedical Investigations (OBI) CV terms used to describe types of preparation methods that produce C2M2 biosamples",
+         "schema": {
+            "fields": [
+               {
+                  "name": "id",
+                  "description": "An OBI CV term",
+                  "type": "string",
+                  "constraints": {
+                     "required": true,
+                     "unique": true
+                  }
+               },
+               {
+                  "name": "name",
+                  "description": "A short, human-readable, machine-read-friendly label for this OBI term",
+                  "type": "string",
+                  "constraints": {
+                     "required": true
+                  }
+               },
+               {
+                  "name": "description",
+                  "description": "A human-readable description of this OBI term",
+                  "type": "string"
+               },
+               {
+                  "name": "synonyms",
+                  "description": "A list of synonyms for this term as identified by the OBI metadata",
+                  "type": "array"
+               }
+            ],
+            "missingValues": [ "" ],
+            "primaryKey": "id"
          }
       },
       {

--- a/cfde_deriva/datapackage.py
+++ b/cfde_deriva/datapackage.py
@@ -1319,6 +1319,7 @@ LIMIT 1;
                 'subject_granularity': 'subject_granularities',
                 'subject_species': 'subject_species',
                 'ncbi_taxonomy': ('ncbi_taxon', 'ncbi_taxons'),
+                'sample_prep_method': 'sample_prep_methods',
                 'assay_type': 'assay_types',
                 'analysis_type': 'analysis_types',
                 'file_format': 'file_formats',

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -777,7 +777,7 @@ class Submission (object):
                 },
             )
 
-        report = frictionless.validate_package(package, trusted=False, original=True, parallel=False)
+        report = frictionless.package.validate.validate(package, original=True, parallel=False)
         if post_process:
             post_process(content_path, packagefile, report)
         if report.stats['errors'] > 0:
@@ -1365,7 +1365,7 @@ WHERE id IS NOT NULL
         try:
             submission.ingest()
         except exception.InvalidDatapackage as e:
-            logger.warn('Rebuild of submission %s encountered error: %s' % (id, e))
+            logger.warning('Rebuild of submission %s encountered error: %s' % (id, e))
             pass
 
     @classmethod

--- a/cfde_deriva/submission.py
+++ b/cfde_deriva/submission.py
@@ -1212,6 +1212,7 @@ WHERE v.id = t.id;
                     registry_dp.doc_cfde_schema.tables[tname]
                     for tname in [
                             'anatomy',
+                            'sample_prep_method',
                             'assay_type',
                             'data_type',
                             'dbgap_study_id',
@@ -1244,6 +1245,8 @@ WHERE v.id = t.id;
                     ("""  SELECT v.id FROM biosample e JOIN core_fact cf ON (e.core_fact = cf.nid) JOIN anatomy v ON (cf.anatomy = v.nid)
                     UNION SELECT v.id FROM collection_anatomy a JOIN anatomy v ON (a.anatomy = v.nid)""",
                      'datapackage_anatomy', 'anatomy'),
+                    ('SELECT v.id FROM biosample e JOIN core_fact cf ON (e.core_fact = cf.nid) JOIN sample_prep_method v ON (cf.sample_prep_method = v.nid)',
+                     'datapackage_sample_prep_method', 'sample_prep_method'),
                     ("""  SELECT v.id FROM biosample e JOIN core_fact cf ON (e.core_fact = cf.nid) JOIN assay_type v ON (cf.assay_type = v.nid)
                     UNION SELECT v.id FROM file e      JOIN core_fact cf ON (e.core_fact = cf.nid) JOIN assay_type v ON (cf.assay_type = v.nid)""",
                      'datapackage_assay_type', 'assay_type'),

--- a/cfde_deriva/tableschema.py
+++ b/cfde_deriva/tableschema.py
@@ -464,6 +464,7 @@ class CatalogConfigurator (object):
                                     { "name": "Phenotype", "url": "/chaise/recordset/#{{$catalog.id}}/CFDE:phenotype" },
                                     { "name": "Protein", "url": "/chaise/recordset/#{{$catalog.id}}/CFDE:protein" },
                                     { "name": "Race", "url": "/chaise/recordset/#{{$catalog.id}}/CFDE:race" },
+                                    { "name": "Sample Prep Method", "url": "/chaise/recordset/#{{$catalog.id}}/CFDE:sample_prep_method" },
                                     { "name": "Sex", "url": "/chaise/recordset/#{{$catalog.id}}/CFDE:sex" },
                                     { "name": "Subject Granularity", "url": "/chaise/recordset/#{{$catalog.id}}/CFDE:subject_granularity" },
                                     { "name": "Subject Role", "url": "/chaise/recordset/#{{$catalog.id}}/CFDE:subject_role" },

--- a/cfde_deriva/tableschema.py
+++ b/cfde_deriva/tableschema.py
@@ -226,7 +226,9 @@ class PortalPackageDataName (PackageDataName):
                 fdoc
                 for fdoc in rschema['fields']
                 # HACK: skip synonyms to reduce DB and export bloat...
-                if fdoc['name'] != 'synonyms'
+                # HACK: skip biosample.assay_type deprecated field...
+                if (fdoc['name'] != 'synonyms'
+                    and (resource['name'] != 'biosample' or fdoc['name'] != 'assay_type'))
             ]
             rschema['primaryKey'] = [ "nid" ]
             rschema['foreignKeys'] = [ ]


### PR DESCRIPTION
This PR adjusts the portal models and ingest process to handle the new C2M2 `biosample.sample_prep_method` field and corresponding new vocab table.

For backwards-compatibility, the prior `biosample.assay_type` field is tolerated but ignored.