### PR TITLE
Facet speedups and restore recordset counts

### DIFF
--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -7158,7 +7158,8 @@
                "show_saved_query": true
             },
             "table_config": {
-               "stable_key_columns": ["id"]
+               "stable_key_columns": ["id"],
+               "aggressive_facet_lookup": true
             },
             "table_display": {
                "*": {
@@ -7230,7 +7231,8 @@
                           {"outbound": ["CFDE", "core_fact_dbgap_study_id_fkey"]},
                           "nid"
                       ],
-                     "entity": true
+                     "entity": true,
+                     "fast_filter_source": [ "dbgap_study_ids" ]
                   },
                   "S_bundle_collection": {
                      "markdown_name": "Bundle Collection",
@@ -7247,7 +7249,8 @@
                         {"sourcekey": "S_core_fact"},
                         {"outbound": ["CFDE", "core_fact_project_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "projects" ]
                   },
                   "S_super_projects": {
                      "markdown_name": "Project",
@@ -7268,7 +7271,8 @@
                         {"outbound": ["CFDE", "core_fact_dcc_dcc_fkey"]},
                         "nid"
                      ],
-                     "entity": true
+                     "entity": true,
+                     "fast_filter_source": [ "dccs" ]
                   },
                   "S_dcc_array": {
                      "markdown_name": "Common Fund Program",
@@ -7288,7 +7292,8 @@
                         {"inbound": ["CFDE", "core_fact_file_format_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_file_format_file_format_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "file_formats" ]
                   },
                   "S_file_format_slim": {
                      "markdown_name": "File Format (slim)",
@@ -7299,7 +7304,8 @@
                         {"outbound": ["CFDE", "core_fact_file_format_file_format_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "file_formats" ]
                   },
                   "S_compression_format": {
                      "markdown_name": "Compression Format",
@@ -7308,7 +7314,8 @@
                         {"sourcekey": "S_core_fact"},
                         {"outbound": ["CFDE", "core_fact_compression_format_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "compression_formats" ]
                   },
                   "S_data_type": {
                      "comment": "Data type of a the file, offering original terms and corresponding \"slim\" terms.",
@@ -7317,7 +7324,8 @@
                         {"inbound": ["CFDE", "core_fact_data_type_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_data_type_data_type_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "data_types" ]
                   },
                   "S_data_type_slim": {
                      "markdown_name": "Data Type (slim)",
@@ -7328,7 +7336,8 @@
                         {"outbound": ["CFDE", "core_fact_data_type_data_type_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "data_types" ]
                   },
                   "S_creation_time": {
                      "comment": "The time when the file was created.",
@@ -7349,7 +7358,8 @@
                         {"inbound": ["CFDE", "core_fact_anatomy_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_anatomy_anatomy_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "anatomies" ]
                   },
                   "S_anatomy_slim": {
                      "markdown_name": "Anatomy (slim)",
@@ -7360,7 +7370,8 @@
                         {"outbound": ["CFDE", "core_fact_anatomy_anatomy_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "anatomies" ]
                   },
                   "S_sample_prep_method": {
                      "comment": "Sample prep method of related biosamples.",
@@ -7369,7 +7380,8 @@
                         {"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "sample_prep_methods" ]
                   },
                   "S_assay_type": {
                      "comment": "Assay type of a file, offering original terms and corresponding \"slim\" terms.",
@@ -7378,7 +7390,8 @@
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "assay_types" ]
                   },
                   "S_assay_type_slim": {
                      "markdown_name": "Assay Type (slim)",
@@ -7389,7 +7402,8 @@
                         {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "assay_types" ]
                   },
                   "S_analysis_type": {
                      "comment": "Analysis type used to generate the file.",
@@ -7397,7 +7411,8 @@
                         {"sourcekey": "S_core_fact"},
                         {"outbound": ["CFDE", "core_fact_analysis_type_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "analysis_types" ]
                   },
                   "S_subject_granularity": {
                      "comment": "The specificity of the subject description, e.g. organism versus cell-line, of subjects described directly or indirectly by the file.",
@@ -7406,7 +7421,8 @@
                         {"inbound": ["CFDE", "core_fact_subject_granularity_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_subject_granularity_subject_granularity_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "subject_granularities" ]
                   },
                   "S_subject_role": {
                      "comment": "The taxonomy role(s) of subjects described directly or indirectly by the file.",
@@ -7415,7 +7431,8 @@
                         {"inbound": ["CFDE", "core_fact_subject_role_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_subject_role_subject_role_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "subject_roles" ]
                   },
                   "S_described_subjects": {
                      "comment": "Subjects described or characterized by the file.",
@@ -7432,7 +7449,8 @@
                         {"inbound": ["CFDE", "core_fact_disease_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_disease_disease_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "diseases_flat" ]
                   },
                   "S_disease_slim": {
                      "markdown_name": "Disease (slim)",
@@ -7443,7 +7461,8 @@
                         {"outbound": ["CFDE", "core_fact_disease_disease_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "diseases_flat" ]
                   },
                   "S_phenotype": {
                      "markdown_name": "Phenotype",
@@ -7453,7 +7472,8 @@
                         {"inbound": ["CFDE", "core_fact_phenotype_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_phenotype_phenotype_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "phenotypes_flat" ]
                   },
                   "S_substance": {
                      "markdown_name": "Substance",
@@ -7463,7 +7483,8 @@
                         {"inbound": ["CFDE", "pubchem_fact_substance_pubchem_fact_fkey"]},
                         {"outbound": ["CFDE", "pubchem_fact_substance_substance_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "substances" ]
                   },
                   "S_compound": {
                      "markdown_name": "Compound",
@@ -7473,7 +7494,8 @@
                         {"inbound": ["CFDE", "pubchem_fact_compound_pubchem_fact_fkey"]},
                         {"outbound": ["CFDE", "pubchem_fact_compound_compound_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "compounds" ]
                   },
                   "S_gene": {
                      "markdown_name": "Gene",
@@ -7483,7 +7505,8 @@
                         {"inbound": ["CFDE", "gene_fact_gene_gene_fact_fkey"]},
                         {"outbound": ["CFDE", "gene_fact_gene_gene_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "genes" ]
                   },
                   "S_part_of_collections": {
                      "markdown_name": "Part of Collection",
@@ -7504,7 +7527,8 @@
                         {"inbound": ["CFDE", "core_fact_ncbi_taxonomy_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ncbi_taxons" ]
                   },
                   "S_taxonomy_slim": {
                      "markdown_name": "Subject Taxonomy (slim)",
@@ -7515,7 +7539,8 @@
                         {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ncbi_taxons" ]
                   },
                   "S_sex": {
                      "comment": "A sex linked to the described subject.",
@@ -7524,7 +7549,8 @@
                         {"inbound": ["CFDE", "core_fact_sex_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_sex_sex_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "sexes" ]
                   },
                   "S_race": {
                      "markdown_name": "Race",
@@ -7534,7 +7560,8 @@
                         {"inbound": ["CFDE", "core_fact_race_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_race_race_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "races" ]
                   },
                   "S_ethnicity": {
                      "comment": "An ethnicity linked to the described subject.",
@@ -7543,7 +7570,8 @@
                         {"inbound": ["CFDE", "core_fact_ethnicity_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_ethnicity_ethnicity_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ethnicities" ]
                   },
                   "S_age_at_enrollment": {
                      "markdown_name": "Age at Enrollment",

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -9,6 +9,7 @@
       },
       "display": {
          "hide_row_count": {
+            "compact": false,
             "*": true
          }
       }

--- a/cfde_deriva/configs/portal/cfde-portal.json
+++ b/cfde_deriva/configs/portal/cfde-portal.json
@@ -5750,7 +5750,8 @@
                "show_saved_query": true
             },
             "table_config": {
-               "stable_key_columns": ["id"]
+               "stable_key_columns": ["id"],
+               "aggressive_facet_lookup": true
             },
             "table_display": {
                "*": {
@@ -5807,7 +5808,8 @@
                         {"inbound": ["CFDE", "core_fact_project_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_project_project_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "projects" ]
                   },
                   "S_project_array": {
                      "markdown_name": "Project",
@@ -5818,6 +5820,7 @@
                         {"outbound": ["CFDE", "core_fact_project_project_fkey"]},
                         "nid"
                      ],
+                     "fast_filter_source": [ "projects" ],
                      "aggregate": "array_d"
                   },
                   "S_dcc": {
@@ -5828,7 +5831,8 @@
                         {"inbound": ["CFDE", "core_fact_dcc_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_dcc_dcc_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "dccs" ]
                   },
                   "S_dcc_array": {
                      "markdown_name": "Common Fund Program",
@@ -5839,6 +5843,7 @@
                         {"outbound": ["CFDE", "core_fact_dcc_dcc_fkey"]},
                         "nid"
                      ],
+                     "fast_filter_source": [ "dccs" ],
                      "aggregate": "array_d"
                   },
                   "S_super_projects": {
@@ -5858,7 +5863,8 @@
                         {"inbound": ["CFDE", "core_fact_file_format_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_file_format_file_format_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "file_formats" ]
                   },
                   "S_file_format_slim": {
                      "markdown_name": "File Format (slim)",
@@ -5869,7 +5875,8 @@
                         {"outbound": ["CFDE", "core_fact_file_format_file_format_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "file_formats" ]
                   },
                   "S_data_type": {
                      "comment": "Data type of a constituent file, offering original terms and corresponding \"slim\" terms.",
@@ -5878,7 +5885,8 @@
                         {"inbound": ["CFDE", "core_fact_data_type_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_data_type_data_type_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "data_types" ]
                   },
                   "S_data_type_slim": {
                      "markdown_name": "Data Type (slim)",
@@ -5889,7 +5897,8 @@
                         {"outbound": ["CFDE", "core_fact_data_type_data_type_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "data_types" ]
                   },
                   "S_sample_prep_method": {
                      "comment": "Sample prep method of a consistuent biosample.",
@@ -5898,7 +5907,8 @@
                         {"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "sample_prep_methods" ]
                   },
                   "S_assay_type": {
                      "comment": "Assay type of a constituent file, offering original terms and corresponding \"slim\" terms.",
@@ -5907,7 +5917,8 @@
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "assay_types" ]
                   },
                   "S_assay_type_slim": {
                      "markdown_name": "Assay Type (slim)",
@@ -5918,7 +5929,8 @@
                         {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "assay_types" ]
                   },
                   "S_ncbi_taxons": {
                      "markdown_name": "Taxonomy",
@@ -5928,7 +5940,8 @@
                         {"inbound": ["CFDE", "core_fact_ncbi_taxonomy_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ncbi_taxons" ]
                   },
                   "S_ncbi_taxons_slim": {
                      "markdown_name": "Taxonomy (slim)",
@@ -5939,7 +5952,8 @@
                         {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ncbi_taxons" ]
                   },
                   "S_taxonomy_assoc": {
                      "markdown_name": "Taxonomy",
@@ -5958,7 +5972,8 @@
                         {"inbound": ["CFDE", "core_fact_subject_granularity_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_subject_granularity_subject_granularity_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "subject_granularities" ]
                   },
                   "S_subject_roles": {
                      "markdown_name": "Subject Role",
@@ -5968,7 +5983,8 @@
                         {"inbound": ["CFDE", "core_fact_subject_role_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_subject_role_subject_role_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "subject_roles" ]
                   },
                   "S_anatomy": {
                      "comment": "Anatomy for biosamples, offering original terms and corresponding \"slim\" terms.",
@@ -5977,7 +5993,8 @@
                         {"inbound": ["CFDE", "core_fact_anatomy_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_anatomy_anatomy_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "anatomies" ]
                   },
                   "S_anatomy_assoc": {
                      "markdown_name": "Anatomy",
@@ -5997,7 +6014,8 @@
                         {"outbound": ["CFDE", "core_fact_anatomy_anatomy_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "anatomies" ]
                   },
                   "S_disease": {
                      "comment": "Disease for collection, biosample, or subject, offering original terms and corresponding \"slim\" terms.",
@@ -6006,7 +6024,8 @@
                         {"inbound": ["CFDE", "core_fact_disease_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_disease_disease_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "diseases_flat" ]
                   },
                   "S_disease_slim": {
                      "markdown_name": "Disease (slim)",
@@ -6017,7 +6036,8 @@
                         {"outbound": ["CFDE", "core_fact_disease_disease_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "diseases_flat" ]
                   },
                   "S_phenotype": {
                      "markdown_name": "Phenotype",
@@ -6027,7 +6047,8 @@
                         {"inbound": ["CFDE", "core_fact_phenotype_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_phenotype_phenotype_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "phenotypes_flat" ]
                   },
                   "S_disease_assoc": {
                      "markdown_name": "Disease",
@@ -6075,7 +6096,8 @@
                         {"inbound": ["CFDE", "pubchem_fact_substance_pubchem_fact_fkey"]},
                         {"outbound": ["CFDE", "pubchem_fact_substance_substance_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "substances" ]
                   },
                   "S_substance_assoc": {
                      "markdown_name": "Substance",
@@ -6094,7 +6116,8 @@
                         {"inbound": ["CFDE", "pubchem_fact_compound_pubchem_fact_fkey"]},
                         {"outbound": ["CFDE", "pubchem_fact_compound_compound_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "compounds" ]
                   },
                   "S_compound_assoc": {
                      "markdown_name": "Compound",
@@ -6113,7 +6136,8 @@
                         {"inbound": ["CFDE", "gene_fact_gene_gene_fact_fkey"]},
                         {"outbound": ["CFDE", "gene_fact_gene_gene_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "genes" ]
                   },
                   "S_gene_assoc": {
                      "markdown_name": "Gene",
@@ -7249,8 +7273,7 @@
                         {"sourcekey": "S_core_fact"},
                         {"outbound": ["CFDE", "core_fact_project_fkey"]},
                         "nid"
-                     ],
-                     "fast_filter_source": [ "projects" ]
+                     ]
                   },
                   "S_super_projects": {
                      "markdown_name": "Project",
@@ -8619,7 +8642,8 @@
                "show_saved_query": true
             },
             "table_config": {
-               "stable_key_columns": ["id"]
+               "stable_key_columns": ["id"],
+               "aggressive_facet_lookup": true
             },
             "table_display": {
                "*": {
@@ -8672,7 +8696,8 @@
                         {"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "sample_prep_methods" ]
                   },
                   "S_assay_type": {
                      "comment": "Assay type of related files, offering original terms and corresponding \"slim\" terms.",
@@ -8681,7 +8706,8 @@
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "assay_types" ]
                   },
                   "S_assay_type_slim": {
                      "markdown_name": "Assay Type (slim)",
@@ -8692,7 +8718,8 @@
                         {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "assay_types" ]
                   },
                   "S_sample_prep_method_local": {
                      "markdown_name": "Sample Prep Method",
@@ -8710,7 +8737,8 @@
                         {"inbound": ["CFDE", "core_fact_anatomy_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_anatomy_anatomy_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "anatomies" ]
                   },
                   "S_anatomy_slim": {
                      "markdown_name": "Anatomy (slim)",
@@ -8721,7 +8749,8 @@
                         {"outbound": ["CFDE", "core_fact_anatomy_anatomy_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "anatomies" ]
                   },
                   "S_disease_search": {
                      "comment": "Disease for collection, biosample, or subject, offering original terms and corresponding \"slim\" terms.",
@@ -8730,7 +8759,8 @@
                         {"inbound": ["CFDE", "core_fact_disease_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_disease_disease_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "diseases_flat" ]
                   },
                   "S_disease_search_slim": {
                      "markdown_name": "Disease (slim)",
@@ -8741,7 +8771,8 @@
                         {"outbound": ["CFDE", "core_fact_disease_disease_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "diseases_flat" ]
                   },
                   "S_phenotype_search": {
                      "markdown_name": "Phenotype",
@@ -8751,7 +8782,8 @@
                         {"inbound": ["CFDE", "core_fact_phenotype_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_phenotype_phenotype_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "phenotypes_flat" ]
                   },
                   "S_disease": {
                      "markdown_name": "Biosample Disease",
@@ -8778,7 +8810,8 @@
                         {"inbound": ["CFDE", "pubchem_fact_substance_pubchem_fact_fkey"]},
                         {"outbound": ["CFDE", "pubchem_fact_substance_substance_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "substances" ]
                   },
                   "S_substance": {
                      "markdown_name": "Substance",
@@ -8797,7 +8830,8 @@
                         {"inbound": ["CFDE", "pubchem_fact_compound_pubchem_fact_fkey"]},
                         {"outbound": ["CFDE", "pubchem_fact_compound_compound_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "compounds" ]
                   },
                   "S_taxonomy": {
                      "markdown_name": "Subject Taxonomy",
@@ -8807,7 +8841,8 @@
                         {"inbound": ["CFDE", "core_fact_ncbi_taxonomy_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ncbi_taxons" ]
                   },
                   "S_taxonomy_slim": {
                      "markdown_name": "Subject Taxonomy (slim)",
@@ -8818,7 +8853,8 @@
                         {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ncbi_taxons" ]
                   },
                   "S_project": {
                      "comment": "The project attributed as the source of the biosample.",
@@ -8836,7 +8872,8 @@
                         {"inbound": ["CFDE", "core_fact_dcc_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_dcc_dcc_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "dccs" ]
                   },
                   "S_dcc_array": {
                      "markdown_name": "Common Fund Program",
@@ -8847,6 +8884,7 @@
                         {"outbound": ["CFDE", "core_fact_dcc_dcc_fkey"]},
                         "nid"
                      ],
+                     "fast_filter_source": [ "dccs" ],
                      "aggregate": "array_d"
                   },
                   "S_super_projects": {
@@ -8878,7 +8916,8 @@
                         {"inbound": ["CFDE", "core_fact_sex_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_sex_sex_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "sexes" ]
                   },
                   "S_race": {
                      "markdown_name": "Race",
@@ -8888,7 +8927,8 @@
                         {"inbound": ["CFDE", "core_fact_race_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_race_race_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "races" ]
                   },
                   "S_ethnicity": {
                      "comment": "An ethnicity linked to the originating subject.",
@@ -8897,7 +8937,8 @@
                         {"inbound": ["CFDE", "core_fact_ethnicity_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_ethnicity_ethnicity_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ethnicities" ]
                   },
                   "S_age_at_enrollment": {
                      "markdown_name": "Age at Enrollment",
@@ -9797,7 +9838,8 @@
                "show_saved_query": true
             },
             "table_config": {
-               "stable_key_columns": ["id"]
+               "stable_key_columns": ["id"],
+               "aggressive_facet_lookup": true
             },
             "table_display": {
                "*": {
@@ -9869,7 +9911,8 @@
                         {"inbound": ["CFDE", "core_fact_dcc_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_dcc_dcc_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "dccs" ]
                   },
                   "S_dcc_array": {
                      "markdown_name": "Common Fund Program",
@@ -9880,6 +9923,7 @@
                         {"outbound": ["CFDE", "core_fact_dcc_dcc_fkey"]},
                         "nid"
                      ],
+                     "fast_filter_source": [ "dccs" ],
                      "aggregate": "array_d"
                   },
                   "S_disease_search": {
@@ -9889,7 +9933,8 @@
                         {"inbound": ["CFDE", "core_fact_disease_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_disease_disease_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "diseases_flat" ]
                   },
                   "S_disease_search_slim": {
                      "markdown_name": "Disease (slim)",
@@ -9900,7 +9945,8 @@
                         {"outbound": ["CFDE", "core_fact_disease_disease_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "diseases_flat" ]
                   },
                   "S_disease": {
                      "markdown_name": "Subject Disease",
@@ -9926,7 +9972,8 @@
                         {"inbound": ["CFDE", "core_fact_phenotype_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_phenotype_phenotype_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "phenotypes_flat" ]
                   },
                   "S_substance_search": {
                      "markdown_name": "Substance",
@@ -9936,7 +9983,8 @@
                         {"inbound": ["CFDE", "pubchem_fact_substance_pubchem_fact_fkey"]},
                         {"outbound": ["CFDE", "pubchem_fact_substance_substance_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "substances" ]
                   },
                   "S_substance": {
                      "markdown_name": "Substance",
@@ -9955,7 +10003,8 @@
                         {"inbound": ["CFDE", "pubchem_fact_compound_pubchem_fact_fkey"]},
                         {"outbound": ["CFDE", "pubchem_fact_compound_compound_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "compounds" ]
                   },
                   "S_compound": {
                      "markdown_name": "Compound",
@@ -9975,7 +10024,8 @@
                         {"inbound": ["CFDE", "gene_fact_gene_gene_fact_fkey"]},
                         {"outbound": ["CFDE", "gene_fact_gene_gene_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "genes" ]
                   },
                   "S_granularity": {
                      "comment": "The specificity of the subject description, e.g. organism versus cell-line.",
@@ -10001,7 +10051,8 @@
                         {"inbound": ["CFDE", "core_fact_race_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_race_race_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "races" ]
                   },
                   "S_race": {
                      "comment": "A race term characterizing this subject.",
@@ -10036,7 +10087,8 @@
                         {"inbound": ["CFDE", "core_fact_subject_role_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_subject_role_subject_role_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "subject_roles" ]
                   },
                   "S_taxonomy": {
                      "markdown_name": "Taxonomy",
@@ -10046,7 +10098,8 @@
                         {"inbound": ["CFDE", "core_fact_ncbi_taxonomy_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ncbi_taxons" ]
                   },
                   "S_taxonomy_slim": {
                      "markdown_name": "Taxonomy (slim)",
@@ -10057,7 +10110,8 @@
                         {"outbound": ["CFDE", "core_fact_ncbi_taxonomy_ncbi_taxon_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "ncbi_taxons" ]
                   },
                   "S_taxonomy_array": {
                      "markdown_name": "Taxonomy",
@@ -10076,7 +10130,8 @@
                         {"inbound": ["CFDE", "core_fact_anatomy_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_anatomy_anatomy_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "anatomies" ]
                   },
                   "S_anatomy_slim": {
                      "markdown_name": "Anatomy (slim)",
@@ -10087,7 +10142,8 @@
                         {"outbound": ["CFDE", "core_fact_anatomy_anatomy_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "anatomies" ]
                   },
                   "S_sample_prep_method": {
                      "comment": "Sample prep method of a biosample.",
@@ -10096,7 +10152,8 @@
                         {"inbound": ["CFDE", "core_fact_sample_prep_method_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_sample_prep_method_sample_prep_method_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "sample_prep_methods" ]
                   },
                   "S_assay_type": {
                      "comment": "Assay type of a file, offering original terms and corresponding \"slim\" terms.",
@@ -10105,7 +10162,8 @@
                         {"inbound": ["CFDE", "core_fact_assay_type_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "assay_types" ]
                   },
                   "S_assay_type_slim": {
                      "markdown_name": "Assay Type (slim)",
@@ -10116,7 +10174,8 @@
                         {"outbound": ["CFDE", "core_fact_assay_type_assay_type_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "assay_types" ]
                   },
                   "S_data_type": {
                      "comment": "Data type of a related file, offering original terms and corresponding \"slim\" terms.",
@@ -10125,7 +10184,8 @@
                         {"inbound": ["CFDE", "core_fact_data_type_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_data_type_data_type_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "data_types" ]
                   },
                   "S_data_type_slim": {
                      "markdown_name": "Data Type (slim)",
@@ -10136,7 +10196,8 @@
                         {"outbound": ["CFDE", "core_fact_data_type_data_type_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "data_types" ]
                   },
                   "S_file_format": {
                      "comment": "File format of a related file, offering original terms and corresponding \"slim\" terms.",
@@ -10145,7 +10206,8 @@
                         {"inbound": ["CFDE", "core_fact_file_format_core_fact_fkey"]},
                         {"outbound": ["CFDE", "core_fact_file_format_file_format_fkey"]},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "file_formats" ]
                   },
                   "S_file_format_slim": {
                      "markdown_name": "File Format (slim)",
@@ -10156,7 +10218,8 @@
                         {"outbound": ["CFDE", "core_fact_file_format_file_format_fkey"]},
                         {"filter": "is_slim", "operand_pattern": "true"},
                         "nid"
-                     ]
+                     ],
+                     "fast_filter_source": [ "file_formats" ]
                   },
                   "S_creation_time": {
                      "comment": "The time when the subject record created.",


### PR DESCRIPTION
This integrates new chaise features, by adjusting UI hints to make use of extra DB content already prepared in earlier revisions. The new chaise feature is controlled by the "fast filter source" directive, which allows chaise to use an alternate filtering mechanism rather than the fully normalized approach with many relational joins.

- facet filtering is accelerated for vocab-based facets
- search results counts are re-enabled now that they can use this faster query path